### PR TITLE
Security hardening + OPENAI_BASE_URL + AI assistant UX polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Local runtime artifacts produced by `node server.js`
+*.crt
+*.key
+.env
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM node:20-alpine
 
-# Install openssl for self-signed cert generation
-RUN apk add --no-cache openssl
+# openssl for self-signed cert generation; libcap for setcap (so the non-root
+# node user can bind low ports 443/80).
+RUN apk add --no-cache openssl libcap \
+ && setcap 'cap_net_bind_service=+ep' "$(readlink -f "$(which node)")"
 
 WORKDIR /app
 
-COPY server.js .
-COPY portainer-run.html .
+# Copy application files and pre-create the cache directory. Use the built-in
+# 'node' user (uid 1000, already present in node:*-alpine images).
+COPY --chown=node:node server.js portainer-run.html ./
+RUN mkdir -p /app/data && chown -R node:node /app
+
+USER node
 
 # Expose HTTPS and HTTP redirect ports
 EXPOSE 443

--- a/portainer-run.html
+++ b/portainer-run.html
@@ -1806,7 +1806,7 @@ IMPORTANT RULES:
 
     const response = await fetch('/ai/triage', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': S.token },
       body: JSON.stringify({
         model: aiModel(),
         max_tokens: 1500,
@@ -1923,7 +1923,7 @@ async function handleComposePaste(yaml) {
     const ctx = buildContext();
     const response = await fetch('/ai/triage', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': S.token },
       body: JSON.stringify({
         model: aiModel(), max_tokens: 2000, stream: false,
         system: `Translate the Docker Compose file into a Portainer Run deployment config.
@@ -4687,7 +4687,7 @@ ${text || '[No log output]'}`;
 
     const response = await fetch('/ai/triage', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': S.token },
       body: JSON.stringify({
         model: aiModel(),
         max_tokens: 2000,

--- a/portainer-run.html
+++ b/portainer-run.html
@@ -68,6 +68,19 @@ nav{border-right:1px solid var(--border);padding:20px 0;background:rgba(17,20,25
 .chat-msg-assistant{align-self:flex-start;background:var(--surface2);border:1px solid var(--border);border-radius:2px 10px 10px 10px;padding:10px 12px;font-size:12px;max-width:95%;line-height:1.6;}
 .chat-msg-assistant p{margin:0 0 6px;} .chat-msg-assistant p:last-child{margin:0;}
 .chat-msg-assistant ul{margin:4px 0;padding-left:16px;}
+.chat-msg-assistant h1,.chat-msg-assistant h2,.chat-msg-assistant h3,.chat-msg-assistant h4,.chat-msg-assistant h5,.chat-msg-assistant h6{font-family:var(--mono);font-weight:600;color:var(--text-bright);margin:8px 0 4px;line-height:1.3;}
+.chat-msg-assistant h1{font-size:14px;}
+.chat-msg-assistant h2{font-size:13px;}
+.chat-msg-assistant h3,.chat-msg-assistant h4{font-size:12px;}
+.chat-msg-assistant h5,.chat-msg-assistant h6{font-size:11px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em;}
+.chat-msg-assistant em{font-style:italic;color:var(--text-bright);}
+.chat-msg-assistant hr{border:none;border-top:1px solid var(--border);margin:10px 0;}
+.chat-msg-assistant blockquote{border-left:2px solid var(--accent-dim);padding:2px 0 2px 8px;margin:6px 0;color:var(--text-dim);}
+.chat-msg-assistant table{border-collapse:collapse;margin:6px 0;width:100%;font-size:11px;}
+.chat-msg-assistant th,.chat-msg-assistant td{border:1px solid var(--border);padding:4px 6px;text-align:left;vertical-align:top;}
+.chat-msg-assistant th{background:var(--bg);color:var(--text-bright);font-weight:600;}
+.chat-msg-assistant code{font-family:var(--mono);font-size:11px;background:var(--bg);border:1px solid var(--border);border-radius:3px;padding:0 4px;color:var(--accent);}
+.chat-msg-assistant pre{background:var(--bg);border:1px solid var(--border);border-radius:4px;padding:8px;overflow-x:auto;margin:6px 0;font-family:var(--mono);font-size:11px;color:var(--text-bright);}
 .chat-action-btn{display:inline-flex;align-items:center;gap:6px;margin-top:8px;background:var(--accent);color:#000;border:none;border-radius:5px;padding:6px 12px;font-size:12px;font-family:var(--mono);cursor:pointer;font-weight:600;}
 .chat-action-btn:hover{opacity:0.85;}
 .chat-action-btn.secondary{background:var(--surface2);color:var(--text-bright);border:1px solid var(--border2);}
@@ -303,7 +316,20 @@ nav{border-right:1px solid var(--border);padding:20px 0;background:rgba(17,20,25
 .ai-body pre{background:var(--surface2);border:1px solid var(--border);border-radius:5px;padding:10px 12px;overflow-x:auto;margin:10px 0;font-family:var(--mono);font-size:12px;color:var(--text-bright);}
 .ai-body ul,.ai-body ol{padding-left:20px;margin-bottom:12px;}
 .ai-body li{margin-bottom:4px;}
-.ai-body h3{font-family:var(--mono);font-size:13px;font-weight:600;color:var(--text-bright);margin:16px 0 8px;}
+.ai-body h1,.ai-body h2,.ai-body h3,.ai-body h4,.ai-body h5,.ai-body h6{font-family:var(--mono);font-weight:600;color:var(--text-bright);margin:16px 0 8px;line-height:1.3;}
+.ai-body h1{font-size:17px;}
+.ai-body h2{font-size:15px;}
+.ai-body h3{font-size:13px;}
+.ai-body h4{font-size:13px;}
+.ai-body h5{font-size:12px;color:var(--text);}
+.ai-body h6{font-size:12px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em;}
+.ai-body em{font-style:italic;color:var(--text-bright);}
+.ai-body hr{border:none;border-top:1px solid var(--border);margin:16px 0;}
+.ai-body blockquote{border-left:3px solid var(--accent-dim);padding:6px 0 6px 12px;margin:10px 0;color:var(--text-dim);background:var(--surface2);border-radius:0 4px 4px 0;}
+.ai-body table{border-collapse:collapse;margin:10px 0;width:100%;font-size:12.5px;}
+.ai-body th,.ai-body td{border:1px solid var(--border);padding:6px 10px;text-align:left;vertical-align:top;}
+.ai-body th{background:var(--surface2);color:var(--text-bright);font-weight:600;}
+.ai-body tr:nth-child(even) td{background:rgba(255,255,255,0.015);}
 .ai-cursor{display:inline-block;width:7px;height:14px;background:var(--accent);animation:blink .8s infinite;vertical-align:middle;border-radius:1px;}
 @keyframes blink{0%,100%{opacity:1}50%{opacity:0}}
 .ai-unavail{display:flex;align-items:center;gap:10px;padding:12px 16px;font-family:var(--mono);font-size:12px;color:var(--text-dim);background:var(--surface2);border-radius:8px;margin-top:12px;}
@@ -1799,7 +1825,11 @@ Session context: ${ctx}${diagnosticData}
 
 IMPORTANT RULES:
 - If the user asks to SCALE an existing service (e.g. "scale nginx to 3"), respond in plain English confirming what you will do. State clearly: "I'll scale [name] to [N] instances." Do NOT output a deploy-config block for scale requests.
-- If the user asks to DEPLOY a NEW service that does not exist yet, output a deploy-config JSON block.
+- If the user asks to DEPLOY a NEW service that does not exist yet, you MUST respond with a fenced code block tagged exactly "deploy-config" (NOT "json", NOT plain JSON, NOT yaml). The app parses this exact tag to populate the Deploy form. Format:
+  \`\`\`deploy-config
+  {"name":"my-app","namespace":"default","instances":1,"exposure":{"type":"NodePort","ports":[80]},"containers":[{"name":"web","image":"nginx:latest","env":[],"cpuReq":"100m","cpuLim":"500m","memReq":"128Mi","memLim":"512Mi","storage":null}],"warnings":[]}
+  \`\`\`
+  Required fields: name, namespace, instances, exposure, containers (array). Each container needs: name, image. Optional per container: env (array of {name,value}), cpuReq/cpuLim/memReq/memLim, storage ({name,size,mountPath} or null). Add a brief sentence before or after the block, never inside.
 - If LIVE DIAGNOSTIC DATA is provided above, you already have the logs, events, and pod status. Analyse them immediately and give a specific answer. NEVER ask the user to go check the logs or metrics themselves — you already have that data. NEVER output a JSON action plan. Just answer in plain English based on what you can see.
 - Never use Kubernetes jargon. Say "instances" not "replicas", "stopped" not "CrashLoopBackOff", "restarting" not "CrashLoopBackOff".
 - Always respond in English. Do not use Chinese, Japanese, Korean, or other non-Latin characters in your reply, even for connector words or internal reasoning. The only exception is when quoting log lines or container output verbatim.`;
@@ -1839,18 +1869,15 @@ IMPORTANT RULES:
     }
     thinking.remove();
     chatHistory.push({ role: 'assistant', content: fullText });
-    const deployMatch = fullText.match(/```deploy-config[^\n]*\n([\s\S]*?)```/);
-    if (deployMatch) {
-      try {
-        const cfg = JSON.parse(deployMatch[1]);
-        chatPendingDeploy = cfg;
-        addChatMessage('assistant', buildDeployPreview(cfg), {
-          actions: [
-            { label: 'Open in Deploy form', onClick: () => applyDeployConfig(cfg) },
-            { label: 'Cancel', secondary: true, onClick: () => { chatPendingDeploy = null; } },
-          ],
-        });
-      } catch(_) { addChatMessage('assistant', fullText); }
+    const cfg = extractDeployConfig(fullText);
+    if (cfg) {
+      chatPendingDeploy = cfg;
+      addChatMessage('assistant', buildDeployPreview(cfg), {
+        actions: [
+          { label: 'Open in Deploy form', onClick: () => applyDeployConfig(cfg) },
+          { label: 'Cancel', secondary: true, onClick: () => { chatPendingDeploy = null; } },
+        ],
+      });
     } else {
       const ap = extractActionProposal(fullText);
       addChatMessage('assistant', fullText, ap || undefined);
@@ -1875,6 +1902,50 @@ function buildDeployPreview(cfg) {
   });
   if (cfg.warnings?.length) p += '\n**Notes:** ' + cfg.warnings.join(' · ');
   return p;
+}
+
+// Tolerant deploy-config extractor. Tries (in order):
+//   1. ```deploy-config fence — the documented format
+//   2. ```json (or any) fence whose JSON has containers[] + name — common LLM drift
+//   3. Bare top-level JSON object with containers[] + name — last resort
+// Returns parsed config or null. Conservative: requires both `name` and a `containers`
+// array so non-deploy JSON in the response is not mistaken for a deploy.
+function extractDeployConfig(text) {
+  function looksLikeDeploy(o) { return o && typeof o === 'object' && typeof o.name === 'string' && Array.isArray(o.containers); }
+
+  var m = text.match(/```deploy-config[^\n]*\n([\s\S]*?)```/);
+  if (m) { try { var c = JSON.parse(m[1]); if (looksLikeDeploy(c)) return c; } catch(_) {} }
+
+  var fenceRe = /```[\w-]*[^\n]*\n([\s\S]*?)```/g;
+  var fm;
+  while ((fm = fenceRe.exec(text)) !== null) {
+    try { var cf = JSON.parse(fm[1]); if (looksLikeDeploy(cf)) return cf; } catch(_) {}
+  }
+
+  if (/"containers"\s*:/.test(text) && /"name"\s*:/.test(text)) {
+    var start = text.indexOf('{');
+    while (start !== -1) {
+      var depth = 0, inStr = false, esc = false;
+      for (var i = start; i < text.length; i++) {
+        var ch = text[i];
+        if (esc) { esc = false; continue; }
+        if (ch === '\\') { esc = true; continue; }
+        if (ch === '"') { inStr = !inStr; continue; }
+        if (inStr) continue;
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            try { var cb = JSON.parse(text.slice(start, i + 1)); if (looksLikeDeploy(cb)) return cb; } catch(_) {}
+            break;
+          }
+        }
+      }
+      start = text.indexOf('{', start + 1);
+    }
+  }
+
+  return null;
 }
 
 function extractActionProposal(text) {
@@ -1952,9 +2023,8 @@ Session: ${ctx}`,
     if (!response.ok) throw new Error('HTTP ' + response.status);
     const data = await response.json();
     const text = (data.content || []).map(b => b.text || '').join('');
-    const m = text.match(/```deploy-config[^\n]*\n([\s\S]*?)```/);
-    if (m) {
-      const cfg = JSON.parse(m[1]);
+    const cfg = extractDeployConfig(text);
+    if (cfg) {
       chatPendingDeploy = cfg;
       chatHistory.push({ role: 'assistant', content: text });
       addChatMessage('assistant', buildDeployPreview(cfg), {
@@ -4763,30 +4833,63 @@ If the application is healthy, say so briefly. If logs are empty but events show
 
 
 function mdToHtml(md) {
-  // Escape HTML first, then apply markdown transforms
-  let h = md
-    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-  // Fenced code blocks
-  h = h.replace(/```[\w]*\n([\s\S]*?)```/g, '<pre>$1</pre>');
-  // Inline code
+  // 1. Escape HTML first; all subsequent transforms operate on safe text
+  let h = md.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  // 2. Fenced code blocks (must run before any inline transforms)
+  h = h.replace(/```[\w-]*\n([\s\S]*?)```/g, (_m, code) => '<pre>' + code + '</pre>');
+
+  // 3. GFM tables: header row + separator row + body rows
+  h = h.replace(
+    /^(\|.+\|)\n(\|[\s:|-]+\|)\n((?:\|.+\|(?:\n|$))+)/gm,
+    (_m, header, _sep, body) => {
+      const cells = (row) => row.replace(/^\||\|$/g, '').split('|').map((c) => c.trim());
+      const heads = cells(header);
+      const rows  = body.trimEnd().split('\n').map(cells);
+      const thead = '<thead><tr>' + heads.map((c) => '<th>' + c + '</th>').join('') + '</tr></thead>';
+      const tbody = '<tbody>' + rows.map(
+        (r) => '<tr>' + r.map((c) => '<td>' + c + '</td>').join('') + '</tr>'
+      ).join('') + '</tbody>';
+      return '<table>' + thead + tbody + '</table>';
+    }
+  );
+
+  // 4. Headers: # through ###### (use [ \t] so we don't eat trailing newlines)
+  h = h.replace(/^(#{1,6})[ \t]+(.+?)[ \t]*$/gm, (_m, hashes, text) => {
+    const lvl = hashes.length;
+    return '<h' + lvl + '>' + text + '</h' + lvl + '>';
+  });
+
+  // 5. Horizontal rule: ---, ***, or ___ on their own line
+  h = h.replace(/^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$/gm, '<hr>');
+
+  // 6. Blockquote (> was escaped to &gt; in step 1). Merge consecutive lines.
+  h = h.replace(/^&gt;[ \t]?(.+)$/gm, '<blockquote>$1</blockquote>');
+  h = h.replace(/<\/blockquote>\n<blockquote>/g, '<br>');
+
+  // 7. Inline code
   h = h.replace(/`([^`\n]+)`/g, '<code>$1</code>');
-  // Bold
+
+  // 8. Bold (must run before italic so ** isn't mis-parsed as two *)
   h = h.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
-  // Headers
-  h = h.replace(/^#{1,3} (.+)$/gm, '<h3>$1</h3>');
-  // Bullet list items
+
+  // 9. Italic — single * around non-whitespace; won't match list bullets ("* item")
+  h = h.replace(/\*(\S(?:[^*\n]*?\S)?)\*/g, '<em>$1</em>');
+
+  // 10. Lists
   h = h.replace(/^[ \t]*[-*] (.+)$/gm, '<li>$1</li>');
-  // Numbered list items
   h = h.replace(/^\d+\. (.+)$/gm, '<li>$1</li>');
-  // Wrap consecutive li in ul
   h = h.replace(/(<li>[\s\S]*?<\/li>)(\n<li>[\s\S]*?<\/li>)*/g, '<ul>$&</ul>');
-  // Double newlines to paragraph breaks
+
+  // 11. Paragraph wrapping
   h = h.replace(/\n\n+/g, '</p><p>');
-  // Wrap in paragraph
   h = '<p>' + h + '</p>';
-  h = h.replace(/<p>(\s*<(?:h3|ul|pre|li))/g, '$1');
-  h = h.replace(/(<\/(?:h3|ul|pre)>)\s*<\/p>/g, '$1');
+
+  // 12. Cleanup: block elements should not be wrapped in <p>
+  h = h.replace(/<p>(\s*<(?:h[1-6]|ul|pre|li|table|hr|blockquote))/g, '$1');
+  h = h.replace(/(<\/(?:h[1-6]|ul|pre|table|blockquote)>|<hr>)\s*<\/p>/g, '$1');
   h = h.replace(/<p>\s*<\/p>/g, '');
+
   return h;
 }
 

--- a/portainer-run.html
+++ b/portainer-run.html
@@ -996,7 +996,12 @@ function toast(msg, type = 'info') {
 }
 
 function esc(s) {
-  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  return String(s)
+    .replace(/&/g,  '&amp;')
+    .replace(/</g,  '&lt;')
+    .replace(/>/g,  '&gt;')
+    .replace(/"/g,  '&quot;')
+    .replace(/'/g,  '&#39;');
 }
 
 function age(ts) {
@@ -1796,7 +1801,8 @@ IMPORTANT RULES:
 - If the user asks to SCALE an existing service (e.g. "scale nginx to 3"), respond in plain English confirming what you will do. State clearly: "I'll scale [name] to [N] instances." Do NOT output a deploy-config block for scale requests.
 - If the user asks to DEPLOY a NEW service that does not exist yet, output a deploy-config JSON block.
 - If LIVE DIAGNOSTIC DATA is provided above, you already have the logs, events, and pod status. Analyse them immediately and give a specific answer. NEVER ask the user to go check the logs or metrics themselves — you already have that data. NEVER output a JSON action plan. Just answer in plain English based on what you can see.
-- Never use Kubernetes jargon. Say "instances" not "replicas", "stopped" not "CrashLoopBackOff", "restarting" not "CrashLoopBackOff".`;
+- Never use Kubernetes jargon. Say "instances" not "replicas", "stopped" not "CrashLoopBackOff", "restarting" not "CrashLoopBackOff".
+- Always respond in English. Do not use Chinese, Japanese, Korean, or other non-Latin characters in your reply, even for connector words or internal reasoning. The only exception is when quoting log lines or container output verbatim.`;
 
     const response = await fetch('/ai/triage', {
       method: 'POST',
@@ -1931,6 +1937,7 @@ RULES:
 - ports from the first service become the exposure config
 - build directives cannot be mapped — add to warnings
 - Change any db hostnames to localhost (since all containers share localhost in a pod)
+- All string values in the JSON (names, warnings, env values) must be in English using Latin characters only. No Chinese, Japanese, Korean or other non-Latin scripts.
 
 Return ONLY valid JSON in a code block tagged deploy-config like this: \`\`\`deploy-config\n{...}\n\`\`\` No other text.
 
@@ -4685,7 +4692,7 @@ ${text || '[No log output]'}`;
         model: aiModel(),
         max_tokens: 2000,
         stream: true,
-        messages: [{ role: 'user', content: `You are an operations assistant helping a user diagnose a containerised application. Use plain English — avoid Kubernetes jargon where possible, and explain technical terms when you must use them.
+        messages: [{ role: 'user', content: `You are an operations assistant helping a user diagnose a containerised application. Use plain English — avoid Kubernetes jargon where possible, and explain technical terms when you must use them. Respond entirely in English using Latin characters only; do not use Chinese, Japanese, Korean, or other non-Latin scripts anywhere in your reply, even for connector words or internal reasoning. The only exception is when quoting log lines or container output verbatim.
 
 Application: ${name}
 Namespace: ${ns}

--- a/server.js
+++ b/server.js
@@ -104,12 +104,32 @@ function readCacheFile() {
   return {};
 }
 
+// Atomic write via tmp-file + rename (rename is atomic on POSIX). Prevents a
+// crash mid-write from leaving a truncated/partial cache.json that breaks the
+// next JSON.parse.
 function writeCacheFile(data) {
+  const tmp = CACHE_FILE + '.tmp.' + process.pid;
   try {
-    fs.writeFileSync(CACHE_FILE, JSON.stringify(data), 'utf8');
+    fs.writeFileSync(tmp, JSON.stringify(data), 'utf8');
+    fs.renameSync(tmp, CACHE_FILE);
   } catch(e) {
     console.warn('[cache] write failed:', e.message);
+    try { fs.unlinkSync(tmp); } catch(_) {}
   }
+}
+
+// Serialise read-modify-write cycles so two concurrent POSTs/DELETEs don't
+// drop one another's update. The in-process queue is sufficient because only
+// this one server process owns the file. If we ever run multiple replicas
+// against a shared cache volume we'd need flock or an external store.
+let cacheMutation = Promise.resolve();
+function mutateCache(fn) {
+  const next = cacheMutation.then(() => fn(readCacheFile())).then(data => {
+    if (data !== undefined) writeCacheFile(data);
+  });
+  // Swallow errors on the chain so one bad mutation doesn't poison future ones.
+  cacheMutation = next.catch(() => {});
+  return next;
 }
 
 function handleCache(req, res) {
@@ -131,27 +151,29 @@ function handleCache(req, res) {
 
   if (req.method === 'POST') {
     readBody(req).then(body => {
-      try {
-        const data  = JSON.parse(body.toString());
-        const all   = readCacheFile();
-        all[key]    = { ...data, savedAt: Date.now() };
-        writeCacheFile(all);
-        res.writeHead(200, { 'Content-Type': 'application/json', ...CORS });
-        res.end(JSON.stringify({ ok: true }));
-      } catch(_) {
+      let data;
+      try { data = JSON.parse(body.toString()); }
+      catch(_) {
         res.writeHead(400, { 'Content-Type': 'application/json', ...CORS });
         res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return;
       }
+      mutateCache(all => {
+        all[key] = { ...data, savedAt: Date.now() };
+        return all;
+      }).then(() => {
+        res.writeHead(200, { 'Content-Type': 'application/json', ...CORS });
+        res.end(JSON.stringify({ ok: true }));
+      });
     });
     return;
   }
 
   if (req.method === 'DELETE') {
-    const all = readCacheFile();
-    delete all[key];
-    writeCacheFile(all);
-    res.writeHead(200, { 'Content-Type': 'application/json', ...CORS });
-    res.end(JSON.stringify({ ok: true }));
+    mutateCache(all => { delete all[key]; return all; }).then(() => {
+      res.writeHead(200, { 'Content-Type': 'application/json', ...CORS });
+      res.end(JSON.stringify({ ok: true }));
+    });
     return;
   }
 

--- a/server.js
+++ b/server.js
@@ -48,6 +48,11 @@ const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY || '';
 const OPENAI_KEY    = process.env.OPENAI_API_KEY    || '';
 const AI_PROVIDER   = process.env.AI_PROVIDER       || (ANTHROPIC_KEY ? 'anthropic' : OPENAI_KEY ? 'openai' : '');
 const OPENAI_MODEL  = process.env.OPENAI_MODEL      || 'gpt-4o';
+// OPENAI_BASE_URL lets users point at any OpenAI-compatible endpoint:
+// Ollama (http://host.docker.internal:11434/v1), vLLM, OpenRouter,
+// LM Studio, Azure OpenAI, etc. Defaults to OpenAI Cloud.
+const OPENAI_BASE_URL = (process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1').replace(/\/+$/, '');
+const OPENAI_ORIGIN   = new url.URL(OPENAI_BASE_URL);
 const PORT          = parseInt(process.env.PORT      || '443');
 const HTTP_PORT     = parseInt(process.env.HTTP_PORT || '80');
 const SSL_CERT_PATH = process.env.SSL_CERT     || '';
@@ -609,8 +614,12 @@ function proxyToOpenAI(req, res, body) {
     'Content-Length': outBody.length,
   };
 
-  const upstream = https.request(
-    { hostname: 'api.openai.com', port: 443, path: '/v1/chat/completions', method: 'POST', headers },
+  const oaiIsHttps = OPENAI_ORIGIN.protocol === 'https:';
+  const oaiPort    = OPENAI_ORIGIN.port ? parseInt(OPENAI_ORIGIN.port) : (oaiIsHttps ? 443 : 80);
+  const oaiPath    = OPENAI_ORIGIN.pathname.replace(/\/$/, '') + '/chat/completions';
+  const oaiTransport = oaiIsHttps ? https : http;
+  const upstream = oaiTransport.request(
+    { hostname: OPENAI_ORIGIN.hostname, port: oaiPort, path: oaiPath, method: 'POST', headers },
     upRes => {
       if (!openaiPayload.stream) {
         // Non-streaming: translate OpenAI response to Anthropic format
@@ -801,7 +810,10 @@ httpsServer.listen(PORT, () => {
   console.log('\n✅  Portainer Run started');
   console.log(`    UI:        https://localhost${PORT !== 443 ? ':' + PORT : ''}`);
   console.log(`    Portainer: ${PORTAINER_URL}`);
-  console.log(`    AI triage: ${AI_PROVIDER ? AI_PROVIDER + ' ✓' : '✗ not set (set ANTHROPIC_API_KEY or OPENAI_API_KEY)'}`);
+  let aiLine = '✗ not set (set ANTHROPIC_API_KEY or OPENAI_API_KEY)';
+  if (AI_PROVIDER === 'anthropic') aiLine = 'anthropic ✓';
+  if (AI_PROVIDER === 'openai')    aiLine = `openai ✓ (${OPENAI_MODEL} @ ${OPENAI_BASE_URL})`;
+  console.log(`    AI triage: ${aiLine}`);
   console.log(`    TLS:       ${SSL_CERT_PATH ? 'provided certs' : 'self-signed (portainer-run.crt)'}`);
   console.log(`    Cache:     ${CACHE_FILE}`);
   console.log(`    Templates: ${TEMPLATE_URL}`);

--- a/server.js
+++ b/server.js
@@ -681,6 +681,59 @@ function proxyToOpenAI(req, res, body) {
   upstream.end();
 }
 
+// Validate the X-API-Key against Portainer. Caller must supply a valid Portainer
+// PAT — without this check anyone reachable at /ai/triage could burn the
+// server's AI credits. Positive results are cached for AUTH_CACHE_TTL_MS so we
+// don't round-trip to Portainer on every AI request; negatives are not cached
+// so rotated/revoked tokens get a fresh check next time.
+const AUTH_CACHE_TTL_MS = 60_000;
+const authCache = new Map();       // sha256(token) → expiresAt (ms)
+
+function validatePortainerToken(token) {
+  const key = cacheKey(token);
+  const now = Date.now();
+  const exp = authCache.get(key);
+  if (exp && exp > now) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    const opts = {
+      hostname: pHost, port: pPort, path: '/api/users/me', method: 'GET',
+      headers: { 'X-API-Key': token, 'Accept': 'application/json' },
+      rejectUnauthorized: false,
+    };
+    const transport = pIsHttps ? https : http;
+    const ureq = transport.request(opts, ures => {
+      ures.resume();
+      const ok = ures.statusCode >= 200 && ures.statusCode < 300;
+      if (ok) authCache.set(key, now + AUTH_CACHE_TTL_MS);
+      resolve(ok);
+    });
+    ureq.on('error', () => resolve(false));
+    ureq.end();
+  });
+}
+
+async function proxyToAI(req, res, body) {
+  if (!AI_PROVIDER) {
+    res.writeHead(503, { 'Content-Type': 'application/json', ...CORS });
+    res.end(JSON.stringify({ error: { message: 'No AI provider configured on server (set ANTHROPIC_API_KEY or OPENAI_API_KEY)' } }));
+    return;
+  }
+  const token = req.headers['x-api-key'] || '';
+  if (!token) {
+    res.writeHead(401, { 'Content-Type': 'application/json', ...CORS });
+    res.end(JSON.stringify({ error: { message: 'X-API-Key header required' } }));
+    return;
+  }
+  const valid = await validatePortainerToken(token);
+  if (!valid) {
+    res.writeHead(401, { 'Content-Type': 'application/json', ...CORS });
+    res.end(JSON.stringify({ error: { message: 'Invalid or expired Portainer token' } }));
+    return;
+  }
+  if (AI_PROVIDER === 'openai')    return proxyToOpenAI(req, res, body);
+  if (AI_PROVIDER === 'anthropic') return proxyToAnthropic(req, res, body);
+}
 
 // ── REQUEST HANDLER ───────────────────────────────────────────────────────────
 async function handleRequest(req, res) {
@@ -724,11 +777,7 @@ async function handleRequest(req, res) {
 
   if (pathname === '/ai/triage') {
     const body = await readBody(req);
-    if (AI_PROVIDER === 'openai') {
-      proxyToOpenAI(req, res, body);
-    } else {
-      proxyToAnthropic(req, res, body);
-    }
+    proxyToAI(req, res, body);
     return;
   }
 


### PR DESCRIPTION
## Summary

A grab-bag of small improvements I've been running on a fork. Each commit is independently landable; happy to split into smaller PRs if you'd prefer.

## What's in this PR

**Security hardening**
- `esc()` now also escapes `"` and `'`, so interpolating Kubernetes values (image tags, env values, labels) inside HTML attributes can't break out of `value="..."` / `title="..."` and inject markup. ~10 attribute-interpolation sites benefit.
- `/ai/triage` now requires a valid Portainer PAT. The existing code only checks the header is present; this validates it against `/api/users/me` (60s positive cache, no negative cache). Without this, anyone reachable at the proxy could burn the server's configured AI credits.
- Cache writes (`cache.json`) are now atomic (`.tmp.<pid>` + rename) and read-modify-write mutations are serialised through a single promise chain, so a crash mid-write can't truncate the file and two concurrent POSTs/DELETEs can't drop each other's update.
- Container now runs as non-root (`node`, uid 1000). `CAP_NET_BIND_SERVICE` is granted on the node binary via `setcap` at build time so binding 80/443 still works. Closes a standard container-hardening gap.

**Functional extension**
- `OPENAI_BASE_URL` env var lets you point the OpenAI provider at any endpoint speaking the `/chat/completions` shape — Ollama, vLLM, OpenRouter, LM Studio, Azure OpenAI, self-hosted gateways. Defaults to `https://api.openai.com/v1` so existing users see no change. One-liner add to `.env.example` and a derived-host/port/path in `proxyToOpenAI`.

**AI assistant UX**
- Markdown rendering in the chat panel and AI analyse panel: `h1`–`h6` (was `h1`–`h3` all collapsed to `h3`), GFM tables, blockquotes, italics (`*em*`), and horizontal rules.
- Tolerant `extractDeployConfig` helper: recognises canonical `deploy-config` fence, any fenced block with `name` + `containers[]`, or bare JSON with the same shape. Smaller models (Qwen, GLM, …) frequently drift to ```json``` or bare output, and the "Open in Deploy form" button otherwise never appears.
- System prompts now explicitly ask the model to reply in English / Latin characters only. Qwen-family models otherwise drift to Chinese tokens on connector words or chain-of-thought output. Benign on models that follow input language by default.

**Housekeeping**
- `.gitignore` for local runtime artifacts (`*.crt`, `*.key`, `.env`, `data/`).

## What's intentionally NOT in here

I have a few more things on my fork but they need design alignment with your v2 work before they're worth a PR:

- Namespace UX (refresh on tab visit, system-namespace filter, `+ New` button, per-namespace ResourceQuota indicator) — collides with the new Deploy Wizard modal.
- Secret / ConfigMap env-var references with a Source dropdown — your v2 already ships Secret refs with a `🔑` toggle on a positional API, which is a different design direction. Happy to talk about merging the approaches separately.

## Compatibility

- All changes default to existing behavior when the relevant env var is unset.
- `OPENAI_BASE_URL` unset → `https://api.openai.com/v1` (current behavior).
- `/ai/triage` auth: the UI already sends `X-API-Key`, so no frontend change is required. Direct `curl` callers will need to pass a valid Portainer PAT.
- Non-root: `setcap` on the node binary preserves 80/443 binding. Tested via `docker compose up -d`.

## Testing

- `docker build` / `docker compose up -d` clean.
- Container verified running as uid 1000, binding 443 and 80.
- Anthropic provider path exercised end-to-end (chat, triage).
- OpenAI default path untouched (still targets `api.openai.com:443/v1/chat/completions`).
- OpenAI custom base URL exercised against Ollama (`http://host.docker.internal:11434/v1` with `qwen3-coder-next`).

Commits are kept small and focused on one thing each — happy to rebase, split, or drop anything on request.
