### PR TITLE
ENCRYPTION_KEY as a mandatory env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ docker run -d \
   -p 443:443 \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   --name portainer-run \
   portainer-run
@@ -286,6 +287,7 @@ docker run -d \
   -p 443:443 \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e OPENAI_API_KEY=sk-... \
   --name portainer-run \
   portainer-run
@@ -299,6 +301,7 @@ docker run -d \
   -p 80:80 \
   -v /path/to/certs:/certs \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   -e SSL_CERT=/certs/fullchain.pem \
   -e SSL_KEY=/certs/privkey.pem \
@@ -314,6 +317,7 @@ docker run -d \
   -p 80:80 \
   -v /data/portainer-run:/app/data \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e ANTHROPIC_API_KEY=sk-ant-... \
   --name portainer-run \
   portainer-run
@@ -326,6 +330,7 @@ docker run -d \
   -p 443:443 \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e TEMPLATE_URL=https://your-server.com/templates.json \
   --name portainer-run \
   portainer-run
@@ -338,6 +343,7 @@ docker run -d \
   -p 8443:8443 \
   -p 8080:8080 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e PORT=8443 \
   -e HTTP_PORT=8080 \
   --name portainer-run \
@@ -352,11 +358,12 @@ On first start the container generates a self-signed TLS certificate (3 year val
 
 ## Environment variables
 
-`PORTAINER_URL` is required. All others are optional.
+`PORTAINER_URL` and `ENCRYPTION_KEY` are required. All others are optional.
 
 | Variable | Default | Description |
 |---|---|---|
 | `PORTAINER_URL` | — | Full URL of your Portainer instance. Example: `https://portainer.example.com:9443` |
+| `ENCRYPTION_KEY` | — | **Required.** Encrypts stored Git target credentials at rest. Must be at least 32 characters. Generate with: `openssl rand -hex 32` |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key. Enables the Assistant and AI triage using Claude. |
 | `OPENAI_API_KEY` | — | OpenAI API key. Enables the Assistant and AI triage using GPT-4o. Set one or the other — not both. Anthropic takes priority if both are set. |
 | `AI_PROVIDER` | auto | Override AI provider: `anthropic` or `openai`. Auto-detected from whichever key is set. |

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ On first start the container generates a self-signed TLS certificate (3 year val
 | Variable | Default | Description |
 |---|---|---|
 | `PORTAINER_URL` | — | Full URL of your Portainer instance. Example: `https://portainer.example.com:9443` |
-| `ENCRYPTION_KEY` | — | **Required.** Encrypts stored Git target credentials at rest. Must be at least 32 characters. Generate with: `openssl rand -hex 32` |
+| `ENCRYPTION_KEY` | — | Encrypts stored Git target credentials at rest. Must be at least 32 characters. Generate with: `openssl rand -hex 32` |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key. Enables the Assistant and AI triage using Claude. |
 | `OPENAI_API_KEY` | — | OpenAI API key. Enables the Assistant and AI triage using GPT-4o. Set one or the other — not both. Anthropic takes priority if both are set. |
 | `AI_PROVIDER` | auto | Override AI provider: `anthropic` or `openai`. Auto-detected from whichever key is set. |

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     environment:
       # ── Required ──────────────────────────────────────────────────────────
       - PORTAINER_URL=https://portainer.example.com:9443
+      # Encrypts stored Git target credentials. Min 32 chars. Generate: openssl rand -hex 32
+      - ENCRYPTION_KEY=<change-me-to-a-rand-32-string>
 
       # ── AI provider (choose one) ───────────────────────────────────────────
       # Anthropic (Claude):

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -45,8 +45,8 @@ data:
 
 ---
 # Secret — sensitive values
-# Add your AI provider key before applying.
-# To encode a value:  echo -n 'your-key-here' | base64
+# Add your ENCRYPTION_KEY and AI provider key before applying.
+# To encode a value:  echo -n 'your-value-here' | base64
 apiVersion: v1
 kind: Secret
 metadata:
@@ -54,6 +54,11 @@ metadata:
   namespace: portainer-run
 type: Opaque
 data:
+  # ── Required: encryption key ────────────────────────────────────────────────
+  # Encrypts stored Git target credentials at rest. Min 32 chars.
+  # Generate: openssl rand -hex 32 | base64
+  ENCRYPTION_KEY: ""
+
   # ── Anthropic (Claude) ──────────────────────────────────────────────────────
   # Base64-encode your key: echo -n 'sk-ant-...' | base64
   ANTHROPIC_API_KEY: ""
@@ -112,6 +117,13 @@ spec:
             - configMapRef:
                 name: portainer-run-config
           env:
+            # ── Encryption key (required) ─────────────────────────────────────
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: portainer-run-secret
+                  key: ENCRYPTION_KEY
+
             # ── Anthropic API key ─────────────────────────────────────────────
             - name: ANTHROPIC_API_KEY
               valueFrom:


### PR DESCRIPTION
ENCRYPTION_KEY is enforced as mandatory at startup — the server exits with an error if it is absent or shorter than 32 characters (see [config.js#L93-L101](https://github.com/portainer/portainer-run/blob/docs/encryption-key-mandatory/server/config.js#L93-L101)).

This was not reflected in the documentation.

- **README** : updated the env vars table intro, added `ENCRYPTION_KEY` as a required entry, and added `-e ENCRYPTION_KEY=...` to all six docker run examples
- **docker-compose.yml** : added under the # Required block
- **kubernetes.yaml** : added to the Secret and wired into the Deployment env section without optional: true
