### PR TITLE
fix: hide system namespaces from namespace picker and block mutations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ HTTP_PORT=80
 # Required for GitOps: encrypts stored Git target credentials at rest.
 # Must be at least 32 characters. Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=change-me-to-a-random-32-char-string
+
+# Optional — comma-separated list of additional namespaces to block from Portainer Run.
+# kube-system, kube-public, kube-node-lease, and portainer are always blocked.
+# NS_DENYLIST=monitoring,cert-manager,ingress-nginx

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ On first start the container generates a self-signed TLS certificate (3 year val
 | `SSL_KEY` | — | Path to TLS private key file. Uses self-signed if not set. |
 | `SSL_CERT_DIR` | `/app` | Directory for self-signed certificate storage. |
 | `CACHE_DIR` | `/app/data` | Directory for session cache file. Mount as a volume to persist across restarts. |
+| `NS_DENYLIST` | — | Comma-separated list of additional namespaces to block from all write operations. `kube-system`, `kube-public`, `kube-node-lease`, and `portainer` are always blocked. Example: `monitoring,cert-manager,ingress-nginx` |
 
 ## Connecting
 

--- a/client/src/lib/deployK8s.js
+++ b/client/src/lib/deployK8s.js
@@ -1,8 +1,7 @@
 import { kubeFetch } from './api.js'
 import { inflightDedupe } from './inflightDedupe.js'
 import { GPU_RESOURCE_KEYS } from './deployFormModel.js'
-
-const SYSTEM_NS = new Set(['kube-system', 'kube-public', 'kube-node-lease', 'portainer'])
+import { useAppStore } from '../store/useAppStore.js'
 
 export { GPU_RESOURCE_KEYS } from './deployFormModel.js'
 
@@ -13,6 +12,7 @@ export { GPU_RESOURCE_KEYS } from './deployFormModel.js'
  */
 export async function fetchNamespaceOptions(token, envId) {
   return inflightDedupe(`k8s:ns-options:${envId}`, async () => {
+  const denylist = new Set(useAppStore.getState().nsDenylist)
   const r = await kubeFetch(token, envId, '/api/v1/namespaces')
   if (r.status === 403 || r.status === 401) {
     return {
@@ -41,7 +41,7 @@ export async function fetchNamespaceOptions(token, envId) {
         return pr.ok ? ns : null
       }),
     )
-  ).filter((ns) => ns && !ns.startsWith('kube-') && !SYSTEM_NS.has(ns))
+  ).filter((ns) => ns && !ns.startsWith('kube-') && !denylist.has(ns))
   if (!accessible.length) {
     return {
       ok: true,

--- a/client/src/lib/deployK8s.js
+++ b/client/src/lib/deployK8s.js
@@ -2,6 +2,8 @@ import { kubeFetch } from './api.js'
 import { inflightDedupe } from './inflightDedupe.js'
 import { GPU_RESOURCE_KEYS } from './deployFormModel.js'
 
+const SYSTEM_NS = new Set(['kube-system', 'kube-public', 'kube-node-lease', 'portainer'])
+
 export { GPU_RESOURCE_KEYS } from './deployFormModel.js'
 
 /**
@@ -39,7 +41,7 @@ export async function fetchNamespaceOptions(token, envId) {
         return pr.ok ? ns : null
       }),
     )
-  ).filter(Boolean)
+  ).filter((ns) => ns && !ns.startsWith('kube-') && !SYSTEM_NS.has(ns))
   if (!accessible.length) {
     return {
       ok: true,

--- a/client/src/services/config.js
+++ b/client/src/services/config.js
@@ -18,6 +18,7 @@ export async function loadServerConfig() {
           : 'Set your Portainer base URL below'
     )
     st().setAi(!!d.aiAvailable, d.aiProvider || 'anthropic', d.baseDomain || '')
+    st().setNsDenylist(d.nsDenylist || [])
   } catch (e) {
     st().setPortainerFromServer(false)
     st().setServerLabel('API proxy not reachable — is the portainer-run server running?')

--- a/client/src/store/useAppStore.js
+++ b/client/src/store/useAppStore.js
@@ -21,6 +21,8 @@ export const useAppStore = create((set, get) => ({
   baseDomain: '',
   /** @type {Record<string, { reason?: string, disabledAt?: string }>} */
   disabledEnvs: {},
+  /** Namespaces blocked from all write operations — populated from /config on startup. */
+  nsDenylist: [],
   cache: { ...initialCache },
   cacheStatus: 'loading' /** 'loading' | 'cached' | 'fresh' | 'stale' */,
 
@@ -50,6 +52,7 @@ export const useAppStore = create((set, get) => ({
   setAi: (isAiAvailable, aiProvider, baseDomain) =>
     set({ isAiAvailable, aiProvider, baseDomain: baseDomain || '' }),
   setDisabledEnvs: (disabledEnvs) => set({ disabledEnvs }),
+  setNsDenylist: (nsDenylist) => set({ nsDenylist: Array.isArray(nsDenylist) ? nsDenylist : [] }),
   setCache: (updater) =>
     set((s) => (typeof updater === 'function' ? { cache: updater(s.cache) } : { cache: updater })),
   setCacheField: (patch) => set((s) => ({ cache: { ...s.cache, ...patch } })),

--- a/server/config.js
+++ b/server/config.js
@@ -32,6 +32,10 @@ export const SSL_KEY_PATH = process.env.SSL_KEY || ''
 export const CERT_DIR = process.env.SSL_CERT_DIR || projectRoot
 export const CACHE_DIR = process.env.CACHE_DIR || path.join(projectRoot, 'data')
 export const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || ''
+export const NS_DENYLIST = (process.env.NS_DENYLIST || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean)
 
 /** Default catalogue: same sample JSON as the repo, served from Git (raw). */
 const DEFAULT_TEMPLATE_URL =

--- a/server/handler.js
+++ b/server/handler.js
@@ -5,6 +5,7 @@ import {
   ANTHROPIC_KEY,
   AI_PROVIDER,
   BASE_DOMAIN,
+  NS_DENYLIST,
   OPENAI_KEY,
   PORTAINER_URL,
 } from './config.js'
@@ -17,6 +18,14 @@ import { proxyToAnthropic } from './proxy/anthropic.js'
 import { proxyToOpenAI } from './proxy/openai.js'
 import { handleConnections } from './routes/connections.js'
 import { handleGitOps } from './routes/gitops.js'
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+const SYSTEM_NS = new Set(['kube-system', 'kube-public', 'kube-node-lease', 'portainer', ...NS_DENYLIST])
+
+function extractNamespace(path) {
+  const m = path.match(/\/namespaces\/([^/]+)/)
+  return m ? m[1] : null
+}
 
 /**
  * @param {import('http').IncomingMessage} req
@@ -71,6 +80,14 @@ export async function handleRequest(req, res) {
     const body = await readBody(req)
     const upstreamPath =
       '/api/' + pathname.slice('/portainer-api/'.length) + (parsed.search || '')
+    if (MUTATING_METHODS.has(req.method)) {
+      const ns = extractNamespace(upstreamPath)
+      if (ns && (ns.startsWith('kube-') || SYSTEM_NS.has(ns))) {
+        res.writeHead(403, { 'Content-Type': 'application/json', ...CORS })
+        res.end(JSON.stringify({ error: `Namespace "${ns}" is a system namespace and cannot be modified through Portainer Run.` }))
+        return
+      }
+    }
     proxyToPortainer(req, res, upstreamPath, body)
     return
   }

--- a/server/handler.js
+++ b/server/handler.js
@@ -50,6 +50,7 @@ export async function handleRequest(req, res) {
         aiAvailable: !!(ANTHROPIC_KEY || OPENAI_KEY),
         aiProvider: AI_PROVIDER,
         baseDomain: BASE_DOMAIN,
+        nsDenylist: [...SYSTEM_NS],
       }),
     )
     return


### PR DESCRIPTION
## Summary

- **Layer 1 (client):** `fetchNamespaceOptions` in `deployK8s.js` now filters out `kube-*` prefixed namespaces and known system namespaces (`kube-system`, `kube-public`, `kube-node-lease`, `portainer`) from the dropdown. Applies to Deploy, Catalogue wizard, and Secrets — all share this single call.
- **Layer 2 (server):** Mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) targeting a system namespace via `/portainer-api/` are rejected with a `403` before reaching Portainer. Prevents bypass via direct API calls from the browser console.
- **Layer 3 (config):** New `NS_DENYLIST` env var lets platform admins extend the blocked list with additional namespaces (e.g. `monitoring,cert-manager,ingress-nginx`) without code changes. Documented in `.env.example` and `README.md`.

`GET` requests are intentionally not blocked — logs, metrics, and revisions must remain readable for any workload regardless of namespace.

The built-in blocked set (`kube-system`, `kube-public`, `kube-node-lease`, `portainer`) cannot be overridden — `NS_DENYLIST` is additive only.

## Context

See server-side enforcement entry point: [`server/handler.js#L82-L88`](https://github.com/portainer/portainer-run/blob/fix/hide-system-namespaces-by-default/server/handler.js#L82-L88)

## Test plan

- [x] Connect with a cluster-admin token — `kube-system`, `kube-public`, `kube-node-lease`, and `portainer` must not appear in any namespace dropdown (Deploy, Catalogue wizard, Secrets)
- [x] Attempt a `POST` to `/portainer-api/v1/namespaces/kube-system/configmaps` directly — must return `403`
- [x] Attempt a `GET` to `/portainer-api/v1/namespaces/kube-system/pods` directly — must pass through
- [x] Set `NS_DENYLIST=monitoring` and verify `monitoring` is absent from the dropdown and mutations to it return `403`


🤖 Generated with [Claude Code](https://claude.com/claude-code)