### PR TITLE
Updated README.md and Compose / Kubernetes manifest examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simplified self-service operations portal for Kubernetes, backed by the Portai
 
 ## Quick Start
 
-Deploy Portainer-Run then access it via `[http|https]://your-ip-address/`.
+Deploy Portainer-Run then access it via `https://your-ip-address/`.
 
 ### Kubernetes
 Refer to [deploy/kubernetes.yaml](deploy/kubernetes.yaml).
@@ -444,7 +444,7 @@ The Assistant is scoped to container operations only and will decline unrelated 
 
 ## Notes on scope
 
-BY design, Portainer Run only surfaces deployments it created. It tags every Deployment, Service, PVC, and Ingress with `managed-by=portainer-run` and filters all views to that label. Workloads deployed through Portainer's own UI or `kubectl` will not appear. Secrets are an exception — the Secrets page and the secret picker in the Deploy form show all secrets in the namespace regardless of origin, because referencing externally-managed secrets is a normal operational requirement.
+By design, Portainer Run only surfaces deployments it created. It tags every Deployment, Service, PVC, and Ingress with `managed-by=portainer-run` and filters all views to that label. Workloads deployed through Portainer's own UI or `kubectl` will not appear. Secrets are an exception — the Secrets page and the secret picker in the Deploy form show all secrets in the namespace regardless of origin, because referencing externally-managed secrets is a normal operational requirement.
 
 Persistent storage volumes cannot be modified after deployment. PVCs are created at deploy time and are not touched by the Edit tab.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # Portainer Run
  
 A simplified self-service operations portal for Kubernetes, backed by the Portainer API.
+
+## Quick Start
+
+Deploy Portainer-Run then access it via `[http|https]://your-ip-address/`.
+
+### Kubernetes
+Refer to [deploy/kubernetes.yaml](deploy/kubernetes.yaml).
+
+### Docker Run
+
+```bash
+docker run -d \
+  -p 443:443 \
+  -p 80:80 \
+  -v /path/to/data/directory:/app/data \
+  -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ANTHROPIC_API_KEY=your-anthropic-api-key-here \
+  -e ENCRYPTION_KEY=change-me-to-a-rand-32-string \
+  --name portainer-run \
+  portainer-run
+```
+
+### Docker Compose
+
+Refer to [deploy/docker-compose.yml](deploy/docker-compose.yml).
  
 ## Why this exists
  
@@ -297,6 +322,7 @@ docker run -d \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   --name portainer-run \
   portainer-run
 ```
@@ -309,6 +335,7 @@ docker run -d \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
   -e OPENAI_API_KEY=sk-... \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   --name portainer-run \
   portainer-run
 ```
@@ -322,6 +349,7 @@ docker run -d \
   -v /path/to/certs:/certs \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e SSL_CERT=/certs/fullchain.pem \
   -e SSL_KEY=/certs/privkey.pem \
   --name portainer-run \
@@ -337,6 +365,7 @@ docker run -d \
   -v /data/portainer-run:/app/data \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   --name portainer-run \
   portainer-run
 ```
@@ -348,6 +377,7 @@ docker run -d \
   -p 443:443 \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e TEMPLATE_URL=https://your-server.com/templates.json \
   --name portainer-run \
   portainer-run
@@ -360,6 +390,7 @@ docker run -d \
   -p 8443:8443 \
   -p 8080:8080 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
+  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
   -e PORT=8443 \
   -e HTTP_PORT=8080 \
   --name portainer-run \
@@ -374,11 +405,12 @@ On first start the container generates a self-signed TLS certificate (3 year val
 
 ## Environment variables
 
-`PORTAINER_URL` is required. All others are optional.
+`PORTAINER_URL` and `ENCRYPTION_KEY` are required. All others are optional.
 
 | Variable | Default | Description |
 |---|---|---|
 | `PORTAINER_URL` | — | Full URL of your Portainer instance. Example: `https://portainer.example.com:9443` |
+| `ENCRYPTION_KEY` | — | Encrypts stored Git target credentials at rest. Must be at least 32 characters. Generate with: `openssl rand -hex 32` |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key. Enables the Assistant and AI triage using Claude. |
 | `OPENAI_API_KEY` | — | OpenAI API key. Enables the Assistant and AI triage using GPT-4o. Set one or the other — not both. Anthropic takes priority if both are set. |
 | `AI_PROVIDER` | auto | Override AI provider: `anthropic` or `openai`. Auto-detected from whichever key is set. |

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ docker run -d \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
+  -e ENCRYPTION_KEY=change-me-to-a-rand-32-string \
   --name portainer-run \
   portainer-run
 ```
@@ -335,7 +335,7 @@ docker run -d \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
   -e OPENAI_API_KEY=sk-... \
-  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
+  -e ENCRYPTION_KEY=change-me-to-a-rand-32-string \
   --name portainer-run \
   portainer-run
 ```
@@ -349,7 +349,7 @@ docker run -d \
   -v /path/to/certs:/certs \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
+  -e ENCRYPTION_KEY=change-me-to-a-rand-32-string \
   -e SSL_CERT=/certs/fullchain.pem \
   -e SSL_KEY=/certs/privkey.pem \
   --name portainer-run \
@@ -365,7 +365,7 @@ docker run -d \
   -v /data/portainer-run:/app/data \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
+  -e ENCRYPTION_KEY=change-me-to-a-rand-32-string \
   --name portainer-run \
   portainer-run
 ```
@@ -377,7 +377,7 @@ docker run -d \
   -p 443:443 \
   -p 80:80 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
-  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
+  -e ENCRYPTION_KEY=change-me-to-a-rand-32-string \
   -e TEMPLATE_URL=https://your-server.com/templates.json \
   --name portainer-run \
   portainer-run
@@ -390,7 +390,7 @@ docker run -d \
   -p 8443:8443 \
   -p 8080:8080 \
   -e PORTAINER_URL=https://portainer.example.com:9443 \
-  -e ENCRYPTION_KEY=<change-me-to-a-rand-32-string> \
+  -e ENCRYPTION_KEY=change-me-to-a-rand-32-string \
   -e PORT=8443 \
   -e HTTP_PORT=8080 \
   --name portainer-run \

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,6 +1,6 @@
 # Portainer Run — Docker Compose deployment
 #
-# Required: set PORTAINER_URL before starting.
+# Required: set PORTAINER_URL and ENCRYPTION_KEY before starting.
 # Optional components are commented out with instructions below.
 #
 # Quick start:
@@ -24,6 +24,8 @@ services:
     environment:
       # ── Required ──────────────────────────────────────────────────────────
       - PORTAINER_URL=https://portainer.example.com:9443
+      # Encrypts stored Git target credentials. Min 32 chars. Generate: openssl rand -hex 32
+      - ENCRYPTION_KEY=change-me-to-a-rand-32-string
 
       # ── AI provider (choose one) ───────────────────────────────────────────
       # Anthropic (Claude):
@@ -50,7 +52,7 @@ services:
       # ── Persistent session cache ──────────────────────────────────────────
       # Without this, the cache is lost on container restart.
       # Uncomment and ensure the host path exists before starting.
-       - portainer-run-dataa:/app/data
+       - portainer-run-data:/app/data
 
       # ── Real TLS certificates ─────────────────────────────────────────────
       # Mount your cert directory and set SSL_CERT / SSL_KEY below.

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -2,7 +2,7 @@
 #
 # Deploys Portainer Run as a single pod in the portainer-run namespace.
 #
-# Required: update PORTAINER_URL in the ConfigMap before applying.
+# Required: update PORTAINER_URL and ENCRYPTION_KEY in the ConfigMap before applying.
 # Optional components are commented out with instructions below.
 #
 # Apply:
@@ -47,6 +47,8 @@ data:
 # Secret — sensitive values
 # Add your AI provider key before applying.
 # To encode a value:  echo -n 'your-key-here' | base64
+# Add your ENCRYPTION_KEY and AI provider key before applying.
+# To encode a value:  echo -n 'your-value-here' | base64
 apiVersion: v1
 kind: Secret
 metadata:
@@ -54,6 +56,11 @@ metadata:
   namespace: portainer-run
 type: Opaque
 data:
+  # ── Required: encryption key ────────────────────────────────────────────────
+  # Encrypts stored Git target credentials at rest. Min 32 chars.
+  # Generate: openssl rand -hex 32 | base64
+  ENCRYPTION_KEY: ""
+
   # ── Anthropic (Claude) ──────────────────────────────────────────────────────
   # Base64-encode your key: echo -n 'sk-ant-...' | base64
   ANTHROPIC_API_KEY: ""
@@ -112,6 +119,13 @@ spec:
             - configMapRef:
                 name: portainer-run-config
           env:
+            # ── Encryption key (required) ─────────────────────────────────────
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: portainer-run-secret
+                  key: ENCRYPTION_KEY
+
             # ── Anthropic API key ─────────────────────────────────────────────
             - name: ANTHROPIC_API_KEY
               valueFrom:


### PR DESCRIPTION
`README.md`:
- Added Quick Start section
- Readded `ENCRYPTION_KEY` references to examples and environment variable table
- Fixed minor typos

`deploy/docker-compose.yml`:
- Added `ENCRYPTION_KEY` environment variable
- Fixed volume name typo

`deploy/kubernetes.yaml`:
- Added `ENCRYPTION_KEY` environment variable