### PR TITLE
Support GitHub Enterprise Server for git targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The Test button on each git target checks connectivity and reports read and writ
 
 For GitHub fine-grained PATs, the token requires Contents (read and write) permission on the target repository. Classic PATs require the `repo` scope.
 
+For **GitHub Enterprise Server**, keep the provider set to GitHub and enter your server host (e.g. `https://github.your-company.com`) in the GitHub server URL field. Portainer Run uses the GitHub-compatible REST API at `/api/v3` on that host. Do not use the "Other" provider for GitHub Enterprise — that path targets the Gitea API (`/api/v1`), which a GitHub Enterprise host does not expose.
+
 ## Catalogue
 
 The Catalogue provides a library of pre-configured application stacks that can be deployed in two clicks. Each template card shows the application name, category, container images, and primary port. Clicking **Deploy Wizard** opens a two-step modal.

--- a/client/src/components/GitTargetForm.jsx
+++ b/client/src/components/GitTargetForm.jsx
@@ -91,6 +91,17 @@ export function GitTargetForm({ initial, onSaved, onCancel }) {
             placeholder="https://git.internal.example.com" mono />
         )}
 
+        {payload.provider === 'github' && (
+          <>
+            <Field label="GitHub server URL (optional)" value={payload.url} onChange={(v) => set('url', v)}
+              placeholder="https://github.your-company.com" mono />
+            <div className="hint">
+              Leave blank for github.com. For GitHub Enterprise Server, enter your host — the
+              GitHub-compatible API at <code>/api/v3</code> is used automatically.
+            </div>
+          </>
+        )}
+
         <Field label="Repository (owner/repo)" value={payload.repo} onChange={(v) => set('repo', v)}
           placeholder="myorg/kubernetes-manifests" mono />
 

--- a/server/proxy/git.js
+++ b/server/proxy/git.js
@@ -25,7 +25,8 @@ export async function getBranches(payload) {
   const headers = buildHeaders(payload)
 
   if (provider === 'github') {
-    const data = await request('GET', `https://api.github.com/repos/${repo}/branches`, headers)
+    const base = githubApiBase(payload)
+    const data = await request('GET', `${base}/repos/${repo}/branches`, headers)
     return data.map((b) => b.name)
   }
   if (provider === 'gitlab') {
@@ -51,7 +52,7 @@ export async function ensureBranch(payload, branch) {
   if (branches.includes(branch)) return { ok: true, created: false }
 
   if (provider === 'github') {
-    const base = 'https://api.github.com'
+    const base = githubApiBase(payload)
     const repoData = await request('GET', `${base}/repos/${repo}`, headers)
     const defaultBranch = repoData.default_branch
     const refData = await request('GET', `${base}/repos/${repo}/git/ref/heads/${defaultBranch}`, headers)
@@ -90,7 +91,7 @@ export async function ensureBranch(payload, branch) {
 async function commitGitHub(payload, branch, message, files) {
   const { repo } = payload
   const headers = buildHeaders(payload)
-  const base = 'https://api.github.com'
+  const base = githubApiBase(payload)
 
   // Get branch SHA — gracefully handle empty/new repos
   let baseSha = null
@@ -207,6 +208,22 @@ async function commitGitea(payload, branch, message, files) {
 
 // --- helpers ---
 
+/**
+ * GitHub REST API base URL for a connection.
+ * - github.com (no url): https://api.github.com
+ * - GitHub Enterprise Server (url set): https://<host>/api/v3
+ * @param {object} payload
+ * @returns {string}
+ */
+function githubApiBase(payload) {
+  const url = (payload.url || '').trim().replace(/\/+$/, '')
+  if (!url) return 'https://api.github.com'
+  // Accept either the web host (https://ghe.example.com) or a full
+  // api base already ending in /api/v3.
+  if (/\/api\/v3$/.test(url)) return url
+  return `${url}/api/v3`
+}
+
 function buildHeaders(payload) {
   if (payload.provider === 'github') {
     const headers = { Accept: 'application/vnd.github+json', 'User-Agent': 'portainer-run' }
@@ -289,7 +306,7 @@ export async function deleteFile(payload, branch, filePath, message) {
 async function deleteFileGitHub(payload, branch, filePath, message) {
   const { repo } = payload
   const headers = buildHeaders(payload)
-  const base = 'https://api.github.com'
+  const base = githubApiBase(payload)
 
   // Get current file SHA — required by GitHub delete API
   const fileData = await request('GET', `${base}/repos/${repo}/contents/${filePath}?ref=${branch}`, headers)
@@ -362,7 +379,7 @@ export async function deleteDirectory(payload, branch, dirPath, message) {
 async function deleteDirectoryGitHub(payload, branch, dirPath, message) {
   const { repo } = payload
   const headers = buildHeaders(payload)
-  const base = 'https://api.github.com'
+  const base = githubApiBase(payload)
   const prefix = dirPath.replace(/\/$/, '') + '/'
 
   // 1. Get current branch commit SHA
@@ -480,7 +497,10 @@ async function deleteDirectoryGitea(payload, branch, dirPath, message) {
  */
 export function buildRepoHttpsUrl(payload) {
   const { provider, repo, url: baseUrl } = payload
-  if (provider === 'github') return `https://github.com/${repo}`
+  if (provider === 'github') {
+    const host = (baseUrl || '').trim().replace(/\/+$/, '').replace(/\/api\/v3$/, '')
+    return host ? `${host}/${repo}` : `https://github.com/${repo}`
+  }
   if (provider === 'gitlab') {
     const base = (baseUrl || 'https://gitlab.com').replace(/\/$/, '')
     return `${base}/${repo}`
@@ -498,7 +518,7 @@ export async function testGitConnection(payload) {
   const headers = buildHeaders(payload)
 
   if (provider === 'github') {
-    const base = 'https://api.github.com'
+    const base = githubApiBase(payload)
 
     // 1. Confirm repo is accessible
     const repoData = await request('GET', `${base}/repos/${repo}`, headers)
@@ -615,7 +635,8 @@ export async function fetchFile(payload, branch, filePath) {
 async function fetchFileGitHub(payload, branch, filePath) {
   const { repo } = payload
   const headers = buildHeaders(payload)
-  const data = await request('GET', `https://api.github.com/repos/${repo}/contents/${filePath}?ref=${branch}`, headers)
+  const base = githubApiBase(payload)
+  const data = await request('GET', `${base}/repos/${repo}/contents/${filePath}?ref=${branch}`, headers)
   if (!data.content) throw new Error('File content not found in GitHub response')
   return Buffer.from(data.content.replace(/\n/g, ''), 'base64').toString('utf8')
 }


### PR DESCRIPTION
## Problem

Adding a git target backed by **GitHub Enterprise Server** never worked, regardless of token type (classic admin or fine-grained).

Root cause:
- The `github` provider hardcoded `https://api.github.com` in every call and showed no URL field, so there was no way to point it at a GHE host.
- Selecting **"Other"** to get a URL field routed the payload to the **Gitea** code path, which hits `/api/v1/...`. A GitHub Enterprise host exposes a GitHub-compatible REST API at `/api/v3/...`, not `/api/v1/`, so every request 404'd. The token was never the issue.

## Fix

- Add a `githubApiBase(payload)` helper: `https://<host>/api/v3` when a server URL is set, `https://api.github.com` otherwise. Accepts either the web host or a URL already ending in `/api/v3`.
- Route all GitHub calls (branches, commit, branch creation, file fetch/delete, directory delete, connection test) through it.
- `buildRepoHttpsUrl` now points the GitOps stack at the GHE host.
- The `github` provider now shows an optional **"GitHub server URL"** field. GitHub Enterprise users keep the provider on GitHub and enter their host.
- README documents GHE setup.

## Verification

Ran the real `testGitConnection` / `getBranches` / `buildRepoHttpsUrl` against a local stand-in GHE server. All requests used `/api/v3`, write permissions were detected, and the repo URL resolved to the host. github.com (no URL) still uses `api.github.com`.

