### PR TITLE
Support self-hosted GitLab for git targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ For GitHub fine-grained PATs, the token requires Contents (read and write) permi
 
 For **GitHub Enterprise Server**, keep the provider set to GitHub and enter your server host (e.g. `https://github.your-company.com`) in the GitHub server URL field. Portainer Run uses the GitHub-compatible REST API at `/api/v3` on that host. Do not use the "Other" provider for GitHub Enterprise — that path targets the Gitea API (`/api/v1`), which a GitHub Enterprise host does not expose.
 
+For **self-hosted GitLab**, keep the provider set to GitLab and enter your server host (e.g. `https://gitlab.your-company.com`) in the GitLab server URL field. Leave it blank for gitlab.com. Portainer Run uses the GitLab API at `/api/v4` on that host.
+
 ## Catalogue
 
 The Catalogue provides a library of pre-configured application stacks that can be deployed in two clicks. Each template card shows the application name, category, container images, and primary port. Clicking **Deploy Wizard** opens a two-step modal.

--- a/client/src/components/GitTargetForm.jsx
+++ b/client/src/components/GitTargetForm.jsx
@@ -102,6 +102,17 @@ export function GitTargetForm({ initial, onSaved, onCancel }) {
           </>
         )}
 
+        {payload.provider === 'gitlab' && (
+          <>
+            <Field label="GitLab server URL (optional)" value={payload.url} onChange={(v) => set('url', v)}
+              placeholder="https://gitlab.your-company.com" mono />
+            <div className="hint">
+              Leave blank for gitlab.com. For self-hosted GitLab, enter your host — the
+              GitLab API at <code>/api/v4</code> is used automatically.
+            </div>
+          </>
+        )}
+
         <Field label="Repository (owner/repo)" value={payload.repo} onChange={(v) => set('repo', v)}
           placeholder="myorg/kubernetes-manifests" mono />
 

--- a/server/proxy/git.js
+++ b/server/proxy/git.js
@@ -30,7 +30,7 @@ export async function getBranches(payload) {
     return data.map((b) => b.name)
   }
   if (provider === 'gitlab') {
-    const base = baseUrl || 'https://gitlab.com'
+    const base = gitlabApiBase(payload)
     const encoded = encodeURIComponent(repo)
     const data = await request('GET', `${base}/api/v4/projects/${encoded}/repository/branches`, headers)
     return data.map((b) => b.name)
@@ -66,7 +66,7 @@ export async function ensureBranch(payload, branch) {
   }
 
   if (provider === 'gitlab') {
-    const base = baseUrl || 'https://gitlab.com'
+    const base = gitlabApiBase(payload)
     const encoded = encodeURIComponent(repo)
     const projData = await request('GET', `${base}/api/v4/projects/${encoded}`, headers)
     await request('POST', `${base}/api/v4/projects/${encoded}/repository/branches`, headers, {
@@ -149,8 +149,8 @@ async function commitGitHub(payload, branch, message, files) {
 }
 
 async function commitGitLab(payload, branch, message, files) {
-  const { repo, url: baseUrl } = payload
-  const base = baseUrl || 'https://gitlab.com'
+  const { repo } = payload
+  const base = gitlabApiBase(payload)
   const encoded = encodeURIComponent(repo)
   const headers = buildHeaders(payload)
 
@@ -222,6 +222,19 @@ function githubApiBase(payload) {
   // api base already ending in /api/v3.
   if (/\/api\/v3$/.test(url)) return url
   return `${url}/api/v3`
+}
+
+/**
+ * GitLab host base URL for a connection.
+ * - gitlab.com (no url): https://gitlab.com
+ * - Self-hosted GitLab (url set): https://<host> (trailing slash trimmed)
+ * The /api/v4 path is appended by each call site.
+ * @param {object} payload
+ * @returns {string}
+ */
+function gitlabApiBase(payload) {
+  const url = (payload.url || '').trim().replace(/\/+$/, '')
+  return url || 'https://gitlab.com'
 }
 
 function buildHeaders(payload) {
@@ -322,8 +335,8 @@ async function deleteFileGitHub(payload, branch, filePath, message) {
 }
 
 async function deleteFileGitLab(payload, branch, filePath, message) {
-  const { repo, url: baseUrl } = payload
-  const base = baseUrl || 'https://gitlab.com'
+  const { repo } = payload
+  const base = gitlabApiBase(payload)
   const encoded = encodeURIComponent(repo)
   const encodedPath = encodeURIComponent(filePath)
   const headers = buildHeaders(payload)
@@ -426,8 +439,8 @@ async function deleteDirectoryGitHub(payload, branch, dirPath, message) {
  * with multiple delete actions in one request.
  */
 async function deleteDirectoryGitLab(payload, branch, dirPath, message) {
-  const { repo, url: baseUrl } = payload
-  const base = baseUrl || 'https://gitlab.com'
+  const { repo } = payload
+  const base = gitlabApiBase(payload)
   const encoded = encodeURIComponent(repo)
   const headers = buildHeaders(payload)
 
@@ -502,7 +515,7 @@ export function buildRepoHttpsUrl(payload) {
     return host ? `${host}/${repo}` : `https://github.com/${repo}`
   }
   if (provider === 'gitlab') {
-    const base = (baseUrl || 'https://gitlab.com').replace(/\/$/, '')
+    const base = gitlabApiBase(payload)
     return `${base}/${repo}`
   }
   const base = (baseUrl || '').replace(/\/$/, '')
@@ -570,7 +583,7 @@ export async function testGitConnection(payload) {
   }
 
   if (provider === 'gitlab') {
-    const base = baseUrl || 'https://gitlab.com'
+    const base = gitlabApiBase(payload)
     const encoded = encodeURIComponent(repo)
     const data = await request('GET', `${base}/api/v4/projects/${encoded}`, headers)
     // access_level: 50=owner, 40=maintainer, 30=developer(push), 20=reporter(read), 10=guest
@@ -642,8 +655,8 @@ async function fetchFileGitHub(payload, branch, filePath) {
 }
 
 async function fetchFileGitLab(payload, branch, filePath) {
-  const { repo, url: baseUrl } = payload
-  const base = baseUrl || 'https://gitlab.com'
+  const { repo } = payload
+  const base = gitlabApiBase(payload)
   const encoded = encodeURIComponent(repo)
   const encodedPath = encodeURIComponent(filePath)
   const headers = buildHeaders(payload)


### PR DESCRIPTION
## Summary

Adds self-hosted GitLab support as a git target, mirroring the GitHub Enterprise Server support already on `develop` (#12).

The server already routed GitLab API calls through an optional base URL, but the git target form never rendered a URL field for the `gitlab` provider, so it was effectively pinned to `gitlab.com`. This exposes the missing field and normalizes the host server-side.

## Changes

- `client/src/components/GitTargetForm.jsx` — optional "GitLab server URL" field for the `gitlab` provider (mirrors the GitHub Enterprise field)
- `server/proxy/git.js` — `gitlabApiBase()` helper that normalizes the host (trims trailing slashes, falls back to `gitlab.com`); all GitLab API call sites routed through it
- `README.md` — self-hosted GitLab note

## Testing

- `node --check server/proxy/git.js` passes.
- GitLab form field mirrors the already-working GitHub Enterprise block.
- Manual verification against a self-hosted host recommended before merge (Test connection button on the git target).
