### PR TITLE
Fix exposure URL showing the same host for every service

### DIFF
--- a/server/env-status.js
+++ b/server/env-status.js
@@ -123,7 +123,7 @@ function resolveStatusReason(pod) {
 
 function resolveUrl(appName, svcs, ings, nodeIp) {
   for (const ing of ings.filter(
-    (i) => i.metadata?.labels?.app === appName || (i.spec?.rules || []).length
+    (i) => i.metadata?.labels?.app === appName || i.metadata?.name === appName
   )) {
     for (const rule of ing.spec?.rules || []) {
       const host = rule.host


### PR DESCRIPTION
## Summary

Fixes the Services list showing the **same exposure URL for every service**. After deploying an app with an Ingress, all other services' Exposure columns changed to that app's host (e.g. every row showed `expense.10.4.124.52.nip.io`).

## Root cause

`resolveUrl()` in `server/env-status.js` filtered ingresses with:

```js
ings.filter((i) => i.metadata?.labels?.app === appName || (i.spec?.rules || []).length)
```

The `|| (i.spec?.rules || []).length` clause is truthy for essentially every ingress, so the app-label filter was defeated — **every app matched every ingress** and returned the first ingress's host. The LoadBalancer and NodePort branches just below it already filter correctly by `labels.app === appName || metadata.name === appName`; the ingress branch was the odd one out.

## Fix

Match the ingress strictly by app label or resource name, consistent with the sibling branches:

```js
ings.filter((i) => i.metadata?.labels?.app === appName || i.metadata?.name === appName)
```

## Notes

- Server-side change — requires a server restart to take effect; there's a 20s status cache (`STATUS_TTL`) plus a client-side resourceVersion cache, so a page refresh after restart shows corrected per-app URLs.
- Services without their own Ingress now correctly show their NodePort/LoadBalancer URL or `—` instead of inheriting another app's host.
