### PR TITLE
Auto-discover config namespace from Kubernetes service account

### DIFF
--- a/client/src/services/config.js
+++ b/client/src/services/config.js
@@ -18,6 +18,7 @@ export async function loadServerConfig() {
           : 'Set your Portainer base URL below'
     )
     st().setAi(!!d.aiAvailable, d.aiProvider || 'anthropic', d.baseDomain || '')
+    if (d.configNamespace) st().setConfigNamespace(d.configNamespace)
     if (d.features) st().setFeatures({
       vibeDeploy:      d.features.vibeDeploy      !== false,
       simpleDeploy:    d.features.simpleDeploy    !== false,

--- a/client/src/services/disabledEnvs.js
+++ b/client/src/services/disabledEnvs.js
@@ -2,10 +2,10 @@ import { kubeFetch } from '../lib/api.js'
 import { useAppStore } from '../store/useAppStore.js'
 
 const CM_NAME = 'portainer-run-config'
-const CM_NS = 'kube-system'
 
 export async function loadDisabledEnvs(token, environments) {
   const st = useAppStore.getState
+  const CM_NS = st().configNamespace
   for (const env of environments) {
     try {
       const r = await kubeFetch(token, env.Id, `/api/v1/namespaces/${CM_NS}/configmaps/${CM_NAME}`)
@@ -35,6 +35,7 @@ export async function loadDisabledEnvs(token, environments) {
 }
 
 export async function saveDisabledEnvs(token, environments, disabledEnvs) {
+  const CM_NS = useAppStore.getState().configNamespace
   const payload = {
     apiVersion: 'v1',
     kind: 'ConfigMap',

--- a/client/src/store/useAppStore.js
+++ b/client/src/store/useAppStore.js
@@ -21,6 +21,7 @@ export const useAppStore = create((set, get) => ({
   isAiAvailable: false,
   aiProvider: 'anthropic',
   baseDomain: '',
+  configNamespace: 'kube-system',
   features: {
     vibeDeploy: true,
     simpleDeploy: true,
@@ -67,6 +68,7 @@ export const useAppStore = create((set, get) => ({
   setUsername: (v) => set({ username: v }),
   setAi: (isAiAvailable, aiProvider, baseDomain) =>
     set({ isAiAvailable, aiProvider, baseDomain: baseDomain || '' }),
+  setConfigNamespace: (v) => set({ configNamespace: v || 'kube-system' }),
   setFeatures: (features) => set({ features }),
   setDisabledEnvs: (disabledEnvs) => set({ disabledEnvs }),
   setCache: (updater) =>

--- a/server/config.js
+++ b/server/config.js
@@ -59,6 +59,18 @@ function resolveTemplateUrl() {
 
 export const TEMPLATE_URL = resolveTemplateUrl()
 export const BASE_DOMAIN = process.env.BASE_DOMAIN || ''
+
+function resolveConfigNamespace() {
+  // When running in Kubernetes, the pod's own namespace is mounted at this path automatically.
+  try {
+    const ns = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/namespace', 'utf8').trim()
+    if (ns) return ns
+  } catch { /* not in Kubernetes */ }
+  // Explicit override, or kube-system for local/non-K8s runs.
+  return process.env.CONFIG_NAMESPACE || 'kube-system'
+}
+
+export const CONFIG_NAMESPACE = resolveConfigNamespace()
 export const CACHE_FILE = path.join(CACHE_DIR, 'cache.json')
 
 // ---------------------------------------------------------------------------

--- a/server/handler.js
+++ b/server/handler.js
@@ -12,6 +12,7 @@ import {
   FEATURE_MANIFEST_BUILDER,
   FEATURE_CATALOGUE,
   FEATURE_SECRETS,
+  CONFIG_NAMESPACE,
 } from './config.js'
 import { handleCache } from './cache.js'
 import { handleEnvStatus } from './env-status.js'
@@ -49,6 +50,7 @@ export async function handleRequest(req, res) {
         aiAvailable: !!(ANTHROPIC_KEY || OPENAI_KEY),
         aiProvider: AI_PROVIDER,
         baseDomain: BASE_DOMAIN,
+        configNamespace: CONFIG_NAMESPACE,
         features: {
           vibeDeploy:      FEATURE_VIBE_DEPLOY,
           simpleDeploy:    FEATURE_SIMPLE_DEPLOY,

--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -25,6 +25,7 @@ import {
   FEATURE_SIMPLE_DEPLOY,
   FEATURE_MANIFEST_BUILDER,
   BASE_DOMAIN,
+  CONFIG_NAMESPACE,
 } from '../config.js'
 import { resolveCallerIdentity, extractToken, portainerGet } from '../lib/identity.js'
 import { resolvePortainerTarget } from '../resolve-portainer.js'
@@ -217,7 +218,7 @@ function buildTools() {
 /**
  * Reads the set of environments an admin has disabled from deploy flows.
  * Stored as a JSON map (keyed by string env Id, truthy = disabled) in the
- * `portainer-run-config` ConfigMap in kube-system — the same source the UI
+ * `portainer-run-config` ConfigMap in CONFIG_NAMESPACE (default: kube-system) — same source as the UI
  * uses. The map is global, so the first environment that returns it wins.
  * Returns {} when no config exists (nothing disabled).
  */
@@ -226,7 +227,7 @@ async function fetchDisabledEnvs(target, token, envIds) {
     try {
       const cm = await portainerGet(
         target, token,
-        `/api/endpoints/${id}/kubernetes/api/v1/namespaces/kube-system/configmaps/portainer-run-config`,
+        `/api/endpoints/${id}/kubernetes/api/v1/namespaces/${CONFIG_NAMESPACE}/configmaps/portainer-run-config`,
       )
       const raw = cm?.data?.disabledEnvs
       if (!raw) continue


### PR DESCRIPTION
When portainer-run runs inside Kubernetes, the pod's own namespace is automatically available at /var/run/secrets/kubernetes.io/serviceaccount/namespace. Use it so the portainer-run-config ConfigMap is read from and written to the same namespace the app is deployed in, with no manual configuration.

Falls back to CONFIG_NAMESPACE env var, then kube-system, for local/non-K8s runs. The resolved namespace is exposed via /config so the browser client uses the same value for both reading and writing the ConfigMap.