### PR TITLE
Restoring the dev server at root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 dist
 .env
+data
+bun.lock
 
 # Auto-generated or local-only TLS (see server/tls.js, SSL_CERT / SSL_KEY / SSL_CERT_DIR)
 portainer-run.crt

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -15,9 +15,11 @@ export default defineConfig({
       '/config': target,
       '/portainer-api': target,
       '/ai': target,
+      '/api': target,
       '/cache': target,
       '/env-status': target,
       '/templates': target,
+      '/mcp': target,
     },
   },
 })

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "type": "module",
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "dev": "bun run scripts/dev.mjs",
+    "dev:ui": "vite client",
+    "start": "bun run server/server.js",
+    "start:node": "node server/server.js",
+    "build": "vite build client",
+    "preview": "vite preview client",
+    "docker:run": "bash scripts/docker-run.sh"
   },
   "dependencies": {
     "react": "^19.0.0",


### PR DESCRIPTION
Fixing the ability to run `bun run dev` in the root of the project. The dev command was only starting the frontend, but not the backend server