### PR TITLE
[DO NOT MERGE] feat(addon): serve app under /run base path [R8S-1084]

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -14,7 +14,7 @@ import { App } from './App'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename="/run">
       <App />
     </BrowserRouter>
   </StrictMode>,

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,6 +7,7 @@ const target = { target: api, secure: false, changeOrigin: true }
 
 export default defineConfig({
   plugins: [react()],
+  base: '/run/',
   build: { outDir: 'dist', assetsDir: 'assets' },
   server: {
     port: 5173,


### PR DESCRIPTION
Set Vite base: '/run/' and React Router basename="/run" so the app
loads, navigates, and deep-links correctly when mounted under /run/
via the Portainer gateway. The gateway strips /run before proxying,
so BFF routes and apiFetch paths are unchanged.
