### PR TITLE
add MCP file chunking

### DIFF
--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -86,12 +86,13 @@ const SERVER_INSTRUCTIONS = [
   '',
   'After deploying, report the access URL to the user. The deploy result has a "url" field; if it is null (NodePort/LoadBalancer addresses are assigned asynchronously), call get_app_status after a short wait to retrieve the URL.',
   '',
-  'Large files (over 100 KB): when a file is too large to include inline in deploy_vibe_app without risk of truncation, use the staged transfer workflow:',
+  'Large files (over 50 KB): when a file is too large to include inline in deploy_vibe_app without risk of truncation, use the staged transfer workflow:',
   '  1. Call file_stage_begin(session_id, path) — choose any unique session_id string.',
-  '  2. Split the file content into plain text chunks of at most 200 KB each.',
-  '  3. Call file_stage_chunk(session_id, chunk_index, data) for each chunk, starting at chunk_index 0.',
-  '     Check that next_expected matches your next chunk_index before proceeding.',
-  '  4. Call file_stage_commit(session_id) — verifies completeness and makes the file available to deploy.',
+  '  2. Split the file content into plain text chunks of at most 20 KB each.',
+  '  3. Call file_stage_chunk for each chunk. Chunks can be sent in parallel — the server indexes them by',
+  '     chunk_index so arrival order does not matter. Issue multiple file_stage_chunk calls simultaneously',
+  '     rather than waiting for each response before sending the next.',
+  '  4. Once all chunks have been confirmed received (next_expected = total chunks), call file_stage_commit(session_id).',
   '  5. Pass the session_id in the stagedFileIds array of deploy_vibe_app instead of inlining the content in files.',
   '  Staged sessions expire after 30 minutes — complete the transfer and deploy within that window.',
 ].join('\n')
@@ -170,10 +171,11 @@ function buildTools() {
   tools.push({
     name: 'file_stage_chunk',
     description:
-      'Send one chunk of a staged file. Call repeatedly with sequential chunk_index values ' +
-      '(0, 1, 2 …) until the complete file content has been sent. Each chunk should be at most ' +
-      '200 KB of plain text — no encoding required. Check next_expected matches your next ' +
-      'chunk_index before continuing; if it does not, resend the indicated chunk.',
+      'Send one chunk of a staged file. Chunks must use sequential chunk_index values (0, 1, 2 …) ' +
+      'but can be sent in parallel — the server stores them by index so arrival order does not matter. ' +
+      'Issue multiple file_stage_chunk calls simultaneously rather than waiting for each response. ' +
+      'Each chunk should be at most 20 KB of plain text — no encoding required. ' +
+      'Once all chunks are sent, verify all next_expected values match, then call file_stage_commit.',
     inputSchema: {
       type: 'object',
       required: ['session_id', 'chunk_index', 'data'],

--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -88,12 +88,14 @@ const SERVER_INSTRUCTIONS = [
   '',
   'Large files (over 50 KB): when a file is too large to include inline in deploy_vibe_app without risk of truncation, use the staged transfer workflow:',
   '  1. Call file_stage_begin(session_id, path) — choose any unique session_id string.',
-  '  2. Split the file content into plain text chunks of at most 20 KB each.',
-  '  3. Call file_stage_chunk for each chunk. Chunks can be sent in parallel — the server indexes them by',
-  '     chunk_index so arrival order does not matter. Issue multiple file_stage_chunk calls simultaneously',
-  '     rather than waiting for each response before sending the next.',
-  '  4. Once all chunks have been confirmed received (next_expected = total chunks), call file_stage_commit(session_id).',
-  '  5. Pass the session_id in the stagedFileIds array of deploy_vibe_app instead of inlining the content in files.',
+  '  2. Split the file content into chunks of at most 20 KB each using bash: `split -b 20480 <file> /tmp/chunk_`',
+  '  3. Determine encoding: for HTML-only or plain text files use encoding "none". For JavaScript, TypeScript,',
+  '     PHP, shell scripts, or any file with backslashes, template literals, or regex, use encoding "base64".',
+  '     With base64: read each chunk and pipe through `base64 -w 0` before passing as data.',
+  '  4. Call file_stage_chunk for each chunk. Chunks can be sent in parallel — the server indexes them by',
+  '     chunk_index so arrival order does not matter. Issue multiple file_stage_chunk calls simultaneously.',
+  '  5. Once all chunks are confirmed received, call file_stage_commit(session_id).',
+  '  6. Pass the session_id in the stagedFileIds array of deploy_vibe_app instead of inlining the content.',
   '  Staged sessions expire after 30 minutes — complete the transfer and deploy within that window.',
 ].join('\n')
 
@@ -175,6 +177,9 @@ function buildTools() {
       'but can be sent in parallel — the server stores them by index so arrival order does not matter. ' +
       'Issue multiple file_stage_chunk calls simultaneously rather than waiting for each response. ' +
       'Each chunk should be at most 20 KB of plain text — no encoding required. ' +
+      'For files containing backslashes, escape sequences, template literals, or regex (JavaScript, ' +
+      'TypeScript, shell scripts), use encoding "base64": read the chunk bytes and pipe through ' +
+      '`base64 -w 0` before passing as data. The server decodes before storing. ' +
       'Once all chunks are sent, verify all next_expected values match, then call file_stage_commit.',
     inputSchema: {
       type: 'object',
@@ -182,7 +187,12 @@ function buildTools() {
       properties: {
         session_id: { type: 'string', description: 'Session ID from file_stage_begin' },
         chunk_index: { type: 'number', description: 'Zero-based chunk index. Send in order starting at 0.' },
-        data: { type: 'string', description: 'Plain text chunk content — no base64 or encoding needed.' },
+        data: { type: 'string', description: 'Chunk content — plain text, or base64-encoded bytes when encoding is "base64".' },
+        encoding: {
+          type: 'string',
+          enum: ['none', 'base64'],
+          description: 'Encoding of the data field. Default: none. Use "base64" for files with special characters — read chunk bytes and pipe through `base64 -w 0`.',
+        },
       },
     },
   })
@@ -573,14 +583,26 @@ function toolFileStageBegin(args) {
 }
 
 function toolFileStageChunk(args) {
-  const { session_id, chunk_index, data } = args
+  const { session_id, chunk_index, data, encoding = 'none' } = args
   if (!session_id) throw new Error('session_id is required')
   if (chunk_index === undefined || chunk_index === null) throw new Error('chunk_index is required')
   if (data === undefined || data === null) throw new Error('data is required')
   const entry = stagingStore.get(session_id)
   if (!entry) throw new Error(`Session "${session_id}" not found — call file_stage_begin first`)
   if (entry.committed) throw new Error(`Session "${session_id}" is already committed`)
-  entry.chunks.set(Number(chunk_index), String(data))
+
+  let decoded
+  if (encoding === 'base64') {
+    try {
+      decoded = Buffer.from(data, 'base64').toString('utf8')
+    } catch {
+      throw new Error(`Failed to decode base64 data for chunk ${chunk_index} — ensure the data field contains valid base64`)
+    }
+  } else {
+    decoded = String(data)
+  }
+
+  entry.chunks.set(Number(chunk_index), decoded)
   entry.createdAt = Date.now() // refresh TTL on activity
   const next_expected = Number(chunk_index) + 1
   return { received: true, chunk_index: Number(chunk_index), next_expected }

--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -88,14 +88,13 @@ const SERVER_INSTRUCTIONS = [
   '',
   'Large files (over 50 KB): when a file is too large to include inline in deploy_vibe_app without risk of truncation, use the staged transfer workflow:',
   '  1. Call file_stage_begin(session_id, path) — choose any unique session_id string.',
-  '  2. Split the file content into chunks of at most 20 KB each using bash: `split -b 20480 <file> /tmp/chunk_`',
-  '  3. Determine encoding: for HTML-only or plain text files use encoding "none". For JavaScript, TypeScript,',
-  '     PHP, shell scripts, or any file with backslashes, template literals, or regex, use encoding "base64".',
-  '     With base64: read each chunk and pipe through `base64 -w 0` before passing as data.',
-  '  4. Call file_stage_chunk for each chunk. Chunks can be sent in parallel — the server indexes them by',
-  '     chunk_index so arrival order does not matter. Issue multiple file_stage_chunk calls simultaneously.',
-  '  5. Once all chunks are confirmed received, call file_stage_commit(session_id).',
-  '  6. Pass the session_id in the stagedFileIds array of deploy_vibe_app instead of inlining the content.',
+  '  2. Split into 15 KB chunks: `split -b 15360 <file> /tmp/chunk_` — this produces chunk files /tmp/chunk_aa, /tmp/chunk_ab, etc.',
+  '  3. Determine encoding: plain HTML/CSS/JSON → encoding "none". JS/TS/PHP/shell or any file with backslashes → encoding "base64" (pipe each chunk through `base64 -w 0`).',
+  '  4. For each chunk, compute its MD5: `md5sum /tmp/chunk_XX | awk \'{print $1}\'` and pass as chunk_md5.',
+  '  5. Call file_stage_chunk for each chunk. Chunks can be sent in parallel — arrival order does not matter.',
+  '     The server verifies the checksum and returns an error if it fails — retry only that chunk.',
+  '  6. Once all chunks are confirmed received, call file_stage_commit(session_id).',
+  '  7. Pass the session_id in the stagedFileIds array of deploy_vibe_app instead of inlining the content.',
   '  Staged sessions expire after 30 minutes — complete the transfer and deploy within that window.',
 ].join('\n')
 
@@ -176,11 +175,13 @@ function buildTools() {
       'Send one chunk of a staged file. Chunks must use sequential chunk_index values (0, 1, 2 …) ' +
       'but can be sent in parallel — the server stores them by index so arrival order does not matter. ' +
       'Issue multiple file_stage_chunk calls simultaneously rather than waiting for each response. ' +
-      'Each chunk should be at most 20 KB of plain text — no encoding required. ' +
-      'For files containing backslashes, escape sequences, template literals, or regex (JavaScript, ' +
-      'TypeScript, shell scripts), use encoding "base64": read the chunk bytes and pipe through ' +
-      '`base64 -w 0` before passing as data. The server decodes before storing. ' +
-      'Once all chunks are sent, verify all next_expected values match, then call file_stage_commit.',
+      'Split files into 15 KB chunks: `split -b 15360 <file> /tmp/chunk_` ' +
+      'For plain text (HTML-only, CSS, JSON): pass raw content, encoding "none". ' +
+      'For files with backslashes, template literals, or regex (JS, TS, PHP, shell): use encoding "base64" — ' +
+      'pipe each chunk through `base64 -w 0` before passing as data. ' +
+      'Always compute a checksum: `md5sum /tmp/chunk_XX | awk \'{print $1}\'` and pass as chunk_md5. ' +
+      'The server verifies integrity and returns an error if the checksum fails — retry that chunk. ' +
+      'Once all chunks confirmed, call file_stage_commit.',
     inputSchema: {
       type: 'object',
       required: ['session_id', 'chunk_index', 'data'],
@@ -192,6 +193,10 @@ function buildTools() {
           type: 'string',
           enum: ['none', 'base64'],
           description: 'Encoding of the data field. Default: none. Use "base64" for files with special characters — read chunk bytes and pipe through `base64 -w 0`.',
+        },
+        chunk_md5: {
+          type: 'string',
+          description: 'MD5 checksum of the raw chunk file (before base64 encoding). Compute with `md5sum /tmp/chunk_XX | awk \'{print $1}\'`. Used by the server to detect truncation or corruption.',
         },
       },
     },
@@ -583,7 +588,7 @@ function toolFileStageBegin(args) {
 }
 
 function toolFileStageChunk(args) {
-  const { session_id, chunk_index, data, encoding = 'none' } = args
+  const { session_id, chunk_index, data, encoding = 'none', chunk_md5 } = args
   if (!session_id) throw new Error('session_id is required')
   if (chunk_index === undefined || chunk_index === null) throw new Error('chunk_index is required')
   if (data === undefined || data === null) throw new Error('data is required')
@@ -602,8 +607,23 @@ function toolFileStageChunk(args) {
     decoded = String(data)
   }
 
+  // Verify checksum if provided — catches truncation or corruption in transit
+  if (chunk_md5) {
+    const actual = crypto.createHash('md5').update(Buffer.from(decoded, 'utf8')).digest('hex')
+    // For base64 encoding, checksum is of the raw bytes, so compare against the decoded buffer
+    const rawMd5 = encoding === 'base64'
+      ? crypto.createHash('md5').update(Buffer.from(data, 'base64')).digest('hex')
+      : actual
+    if (rawMd5 !== chunk_md5.toLowerCase().trim()) {
+      throw new Error(
+        `Checksum mismatch for chunk ${chunk_index} — expected ${chunk_md5}, got ${rawMd5}. ` +
+        `The chunk was corrupted or truncated in transit. Resend this chunk.`
+      )
+    }
+  }
+
   entry.chunks.set(Number(chunk_index), decoded)
-  entry.createdAt = Date.now() // refresh TTL on activity
+  entry.createdAt = Date.now()
   const next_expected = Number(chunk_index) + 1
   return { received: true, chunk_index: Number(chunk_index), next_expected }
 }

--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -33,6 +33,28 @@ import { getConnectionsForUser } from '../models/connection.js'
 import { handleVibe } from './vibe.js'
 import { resolveUrl } from '../env-status.js'
 
+// ---------------------------------------------------------------------------
+// Staging store — chunked file transfer for large files
+//
+// Keyed by caller-supplied session_id. Each entry holds the received chunks
+// (a Map<index, string>) until file_stage_commit assembles them into a single
+// content string. Committed entries are then referenced by deploy_vibe_app
+// via the stagedFileIds parameter.
+//
+// Entries expire after STAGING_TTL_MS of inactivity. purgeStagingStore() is
+// called on every file_stage_begin to reclaim memory without a background timer.
+// ---------------------------------------------------------------------------
+
+const stagingStore = new Map()
+const STAGING_TTL_MS = 30 * 60 * 1000 // 30 minutes
+
+function purgeStagingStore() {
+  const now = Date.now()
+  for (const [id, entry] of stagingStore) {
+    if (now - entry.createdAt > STAGING_TTL_MS) stagingStore.delete(id)
+  }
+}
+
 const MCP_VERSION = '2024-11-05'
 const SERVER_INFO = { name: 'portainer-run', version: '1.0.0' }
 
@@ -63,6 +85,15 @@ const SERVER_INSTRUCTIONS = [
   'Always show a summary of the chosen settings and get explicit confirmation before calling deploy_vibe_app.',
   '',
   'After deploying, report the access URL to the user. The deploy result has a "url" field; if it is null (NodePort/LoadBalancer addresses are assigned asynchronously), call get_app_status after a short wait to retrieve the URL.',
+  '',
+  'Large files (over 100 KB): when a file is too large to include inline in deploy_vibe_app without risk of truncation, use the staged transfer workflow:',
+  '  1. Call file_stage_begin(session_id, path) — choose any unique session_id string.',
+  '  2. Split the file content into plain text chunks of at most 200 KB each.',
+  '  3. Call file_stage_chunk(session_id, chunk_index, data) for each chunk, starting at chunk_index 0.',
+  '     Check that next_expected matches your next chunk_index before proceeding.',
+  '  4. Call file_stage_commit(session_id) — verifies completeness and makes the file available to deploy.',
+  '  5. Pass the session_id in the stagedFileIds array of deploy_vibe_app instead of inlining the content in files.',
+  '  Staged sessions expire after 30 minutes — complete the transfer and deploy within that window.',
 ].join('\n')
 
 // ---------------------------------------------------------------------------
@@ -109,6 +140,62 @@ function buildTools() {
       required: ['envId'],
       properties: {
         envId: { type: 'string', description: 'Environment ID from list_environments' },
+      },
+    },
+  })
+
+  tools.push({
+    name: 'file_stage_begin',
+    description:
+      'Start a staged file transfer session for a single file. Use this instead of inlining content ' +
+      'in deploy_vibe_app when a file exceeds ~100 KB. Call file_stage_chunk to send the content in ' +
+      'sequential chunks, then file_stage_commit to finalise. Pass the session_id to deploy_vibe_app ' +
+      'via the stagedFileIds parameter.',
+    inputSchema: {
+      type: 'object',
+      required: ['session_id', 'path'],
+      properties: {
+        session_id: {
+          type: 'string',
+          description: 'A unique identifier for this transfer session, e.g. a UUID or descriptive slug.',
+        },
+        path: {
+          type: 'string',
+          description: 'Relative file path as it will appear in the deployed app, e.g. index.html or src/app.js',
+        },
+      },
+    },
+  })
+
+  tools.push({
+    name: 'file_stage_chunk',
+    description:
+      'Send one chunk of a staged file. Call repeatedly with sequential chunk_index values ' +
+      '(0, 1, 2 …) until the complete file content has been sent. Each chunk should be at most ' +
+      '200 KB of plain text — no encoding required. Check next_expected matches your next ' +
+      'chunk_index before continuing; if it does not, resend the indicated chunk.',
+    inputSchema: {
+      type: 'object',
+      required: ['session_id', 'chunk_index', 'data'],
+      properties: {
+        session_id: { type: 'string', description: 'Session ID from file_stage_begin' },
+        chunk_index: { type: 'number', description: 'Zero-based chunk index. Send in order starting at 0.' },
+        data: { type: 'string', description: 'Plain text chunk content — no base64 or encoding needed.' },
+      },
+    },
+  })
+
+  tools.push({
+    name: 'file_stage_commit',
+    description:
+      'Finalise a staged file after all chunks have been sent. Assembles the chunks in index order, ' +
+      'verifies there are no gaps, and makes the file available to deploy_vibe_app via stagedFileIds. ' +
+      'Returns the assembled file path and size for verification.',
+    inputSchema: {
+      type: 'object',
+      required: ['session_id'],
+      properties: {
+        session_id: { type: 'string', description: 'Session ID from file_stage_begin' },
       },
     },
   })
@@ -188,6 +275,14 @@ function buildTools() {
           branch: {
             type: 'string',
             description: 'Git branch for manifests. Default: main.',
+          },
+          stagedFileIds: {
+            type: 'array',
+            description:
+              'Session IDs of files pre-staged via file_stage_begin / file_stage_chunk / file_stage_commit. ' +
+              'Staged files are merged with any inline files in the files array before deployment. ' +
+              'Use this for files larger than ~100 KB instead of inlining their content.',
+            items: { type: 'string' },
           },
         },
       },
@@ -453,6 +548,64 @@ function detectRuntimeForFiles(files, forcedId) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Staged file transfer — tool implementations
+// ---------------------------------------------------------------------------
+
+function toolFileStageBegin(args) {
+  const { session_id, path } = args
+  if (!session_id) throw new Error('session_id is required')
+  if (!path) throw new Error('path is required')
+  purgeStagingStore()
+  if (stagingStore.has(session_id)) {
+    throw new Error(`Session "${session_id}" already exists — use a different session_id or commit the existing session first`)
+  }
+  stagingStore.set(session_id, {
+    path,
+    chunks: new Map(),
+    committed: false,
+    content: null,
+    createdAt: Date.now(),
+  })
+  return { accepted: true, session_id, path }
+}
+
+function toolFileStageChunk(args) {
+  const { session_id, chunk_index, data } = args
+  if (!session_id) throw new Error('session_id is required')
+  if (chunk_index === undefined || chunk_index === null) throw new Error('chunk_index is required')
+  if (data === undefined || data === null) throw new Error('data is required')
+  const entry = stagingStore.get(session_id)
+  if (!entry) throw new Error(`Session "${session_id}" not found — call file_stage_begin first`)
+  if (entry.committed) throw new Error(`Session "${session_id}" is already committed`)
+  entry.chunks.set(Number(chunk_index), String(data))
+  entry.createdAt = Date.now() // refresh TTL on activity
+  const next_expected = Number(chunk_index) + 1
+  return { received: true, chunk_index: Number(chunk_index), next_expected }
+}
+
+function toolFileStageCommit(args) {
+  const { session_id } = args
+  if (!session_id) throw new Error('session_id is required')
+  const entry = stagingStore.get(session_id)
+  if (!entry) throw new Error(`Session "${session_id}" not found — call file_stage_begin first`)
+  if (entry.committed) throw new Error(`Session "${session_id}" is already committed`)
+  // Verify chunks are contiguous before assembling
+  const indices = Array.from(entry.chunks.keys()).sort((a, b) => a - b)
+  if (indices.length === 0) throw new Error(`Session "${session_id}" has no chunks — send at least one chunk before committing`)
+  for (let i = 0; i < indices.length; i++) {
+    if (indices[i] !== i) {
+      throw new Error(`Missing chunk ${i} in session "${session_id}" — received indices: ${indices.join(', ')}. Resend the missing chunk before committing.`)
+    }
+  }
+  const content = indices.map((i) => entry.chunks.get(i)).join('')
+  entry.content = content
+  entry.chunks = null // free the per-chunk map
+  entry.committed = true
+  entry.createdAt = Date.now() // refresh TTL post-commit
+  return { ok: true, session_id, path: entry.path, size: content.length }
+}
+
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
 function pickNodeIp(nodes) {
@@ -500,12 +653,25 @@ async function toolDeployVibeApp(req, args, caller) {
 
   const {
     appName, envId, namespace, gitTargetId,
-    files = [], envVars, ingress = {}, branch = 'main',
-    runtime = 'auto',
+    files: inlineFiles = [], envVars, ingress = {}, branch = 'main',
+    runtime = 'auto', stagedFileIds = [],
   } = args
 
-  if (!appName || !envId || !namespace || !gitTargetId || !files.length) {
-    throw new Error('appName, envId, namespace, gitTargetId, and files are all required')
+  if (!appName || !envId || !namespace || !gitTargetId) {
+    throw new Error('appName, envId, namespace, and gitTargetId are all required')
+  }
+
+  // Resolve staged files and merge with any inline files
+  const stagedFiles = stagedFileIds.map((sid) => {
+    const entry = stagingStore.get(sid)
+    if (!entry) throw new Error(`Staged file session "${sid}" not found — ensure file_stage_commit was called and the session has not expired (30 min TTL)`)
+    if (!entry.committed) throw new Error(`Staged file session "${sid}" has not been committed — call file_stage_commit before deploying`)
+    return { path: entry.path, content: entry.content }
+  })
+  const files = [...inlineFiles, ...stagedFiles]
+
+  if (!files.length) {
+    throw new Error('At least one file is required — provide files inline or via stagedFileIds')
   }
 
   // Default exposure: when a base domain is configured we can derive a real
@@ -746,6 +912,15 @@ async function dispatch(method, params, req, caller) {
           break
         case 'list_ingress_classes':
           toolResult = await toolListIngressClasses(req, args)
+          break
+        case 'file_stage_begin':
+          toolResult = toolFileStageBegin(args)
+          break
+        case 'file_stage_chunk':
+          toolResult = toolFileStageChunk(args)
+          break
+        case 'file_stage_commit':
+          toolResult = toolFileStageCommit(args)
           break
         case 'deploy_vibe_app':
           toolResult = await toolDeployVibeApp(req, args, caller)


### PR DESCRIPTION
Staging store is an in-memory Map with a 30-minute TTL. No database changes, no disk writes. purgeStagingStore() runs on every file_stage_begin call rather than on a background timer, which is appropriate for a server-side module that can't manage its own cleanup lifecycle cleanly. Three new MCP tools: file_stage_begin, file_stage_chunk, file_stage_commit. The chunk functions are synchronous (no async needed) since they only touch the in-memory store. Chunk gap detection happens at commit time -- if chunk 2 was dropped and you call commit, it throws with the specific missing index so the caller knows exactly what to retry. deploy_vibe_app now destructures stagedFileIds = [] alongside inlineFiles and merges both before the rest of the deploy logic runs. The files validation error message was also updated to reflect both paths. SERVER_INSTRUCTIONS now includes the 5-step staged workflow at the end, so any MCP-compliant client surfaces it to the model automatically. The threshold hint (100 KB) gives the model a concrete decision point.