### PR TITLE
fixing bugs, and addressing the FR's

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
           push: false
           load: false
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            PORTAINER_RUN_VERSION=${{ needs.tag.outputs.value }}
           tags: ${{ env.IMAGE_NAME }}:${{ needs.tag.outputs.value }}
           outputs: type=oci,dest=/tmp/image.tar
 
@@ -91,6 +93,8 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            PORTAINER_RUN_VERSION=${{ needs.tag.outputs.value }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.tag.outputs.value }}
           sbom: true
           provenance: mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,9 @@ EXPOSE 80
 
 ENV NODE_ENV=production
 
+# Release version, supplied by the release workflow (--build-arg PORTAINER_RUN_VERSION=...).
+# Defaults to 'dev' for local and PR builds.
+ARG PORTAINER_RUN_VERSION=dev
+ENV PORTAINER_RUN_VERSION=$PORTAINER_RUN_VERSION
+
 CMD ["bun", "run", "server/server.js"]

--- a/client/src/app-shell.css
+++ b/client/src/app-shell.css
@@ -100,7 +100,8 @@ a.app-breadcrumbs-home:hover{
 body.chat-open .main{margin-right:360px;}
 .main{display:grid;grid-template-columns:220px 1fr;height:calc(100vh - var(--app-header-h));min-height:0;transition:margin-right .2s ease;}
 /* Sidebar only — do not use bare `nav` (breadcrumbs also use <nav>) */
-.main > nav{border-right:1px solid var(--border);padding:20px 0;background:rgba(17,20,25,.6);}
+.main > nav{border-right:1px solid var(--border);padding:20px 0;background:rgba(17,20,25,.6);display:flex;flex-direction:column;}
+.sidebar-version{margin-top:auto;padding:12px 12px 2px;font-family:var(--mono);font-size:11px;color:var(--text-dim);letter-spacing:.02em;}
 .nav-label{font-family:var(--mono);font-size:10px;font-weight:500;color:#b8c8d8;letter-spacing:.12em;text-transform:uppercase;padding:10px 12px 6px;}
 .nav-section{padding:0 12px;margin-bottom:4px;}
 .nav-item{display:flex;align-items:center;gap:10px;padding:9px 12px;border-radius:6px;cursor:pointer;color:var(--text);font-size:13px;transition:background .12s,color .12s,border-color .12s;user-select:none;text-decoration:none;border:1px solid transparent;}

--- a/client/src/app-shell.css
+++ b/client/src/app-shell.css
@@ -101,7 +101,7 @@ body.chat-open .main{margin-right:360px;}
 .main{display:grid;grid-template-columns:220px 1fr;height:calc(100vh - var(--app-header-h));min-height:0;transition:margin-right .2s ease;}
 /* Sidebar only — do not use bare `nav` (breadcrumbs also use <nav>) */
 .main > nav{border-right:1px solid var(--border);padding:20px 0;background:rgba(17,20,25,.6);display:flex;flex-direction:column;}
-.sidebar-version{margin-top:auto;padding:12px 12px 2px;font-family:var(--mono);font-size:11px;color:var(--text-dim);letter-spacing:.02em;}
+.sidebar-version{margin-top:auto;padding:12px 12px 2px;font-family:var(--mono);font-size:11px;color:var(--text-dim);letter-spacing:.02em;text-align:center;}
 .nav-label{font-family:var(--mono);font-size:10px;font-weight:500;color:#b8c8d8;letter-spacing:.12em;text-transform:uppercase;padding:10px 12px 6px;}
 .nav-section{padding:0 12px;margin-bottom:4px;}
 .nav-item{display:flex;align-items:center;gap:10px;padding:9px 12px;border-radius:6px;cursor:pointer;color:var(--text);font-size:13px;transition:background .12s,color .12s,border-color .12s;user-select:none;text-decoration:none;border:1px solid transparent;}

--- a/client/src/components/DeleteModal.jsx
+++ b/client/src/components/DeleteModal.jsx
@@ -1,16 +1,12 @@
 import { useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useAppStore } from '../store/useAppStore.js'
-import { kubeFetch } from '../lib/api.js'
-import { refreshCache } from '../services/refreshDeployments.js'
-import { deleteAppManifest } from '../lib/gitTargets.js'
+import { deleteApp } from '../services/deleteApp.js'
 import { ROUTES } from '../lib/routes.js'
 
 export function DeleteModal() {
   const deleteTarget = useAppStore((s) => s.deleteTarget)
   const setDeleteTarget = useAppStore((s) => s.setDeleteTarget)
-  const token = useAppStore((s) => s.token)
-  const [deleting, setDeleting] = useState(false)
   const [deleteManifest, setDeleteManifest] = useState(false)
   const [confirmText, setConfirmText] = useState('')
   const navigate = useNavigate()
@@ -18,80 +14,29 @@ export function DeleteModal() {
 
   if (!deleteTarget) return null
 
-  const { envId, ns, name, gitTargetId, gitBranch, gitPath, vibeSourcePath } = deleteTarget
+  const { ns, name, gitTargetId, gitBranch, gitPath, vibeSourcePath } = deleteTarget
   const isVibeDeploy = Boolean(vibeSourcePath)
   const isGitOps = Boolean(gitTargetId && gitBranch && gitPath)
 
-  async function confirm() {
-    setDeleting(true)
-    try {
-      // 1. Read Deployment before deleting so we can find all PVC names from spec.volumes
-      let pvcNames = [name] // fallback: assume PVC shares the deployment name
-      try {
-        const depRes = await kubeFetch(token, envId, `/apis/apps/v1/namespaces/${ns}/deployments/${name}`)
-        if (depRes.ok) {
-          const dep = await depRes.json()
-          const vols = dep?.spec?.template?.spec?.volumes || []
-          const fromSpec = vols
-            .filter((v) => v.persistentVolumeClaim?.claimName)
-            .map((v) => v.persistentVolumeClaim.claimName)
-          if (fromSpec.length > 0) pvcNames = fromSpec
-        }
-      } catch { /* non-fatal — fall through to name-based fallback */ }
+  function confirm() {
+    // Capture everything the delete needs, then close the modal immediately.
+    // The delete runs detached (services/deleteApp) so opening a second delete
+    // right after cannot inherit this one's in-progress state (issue #44).
+    const target = deleteTarget
+    const alsoManifest = deleteManifest
+    const wasOnDetail =
+      loc.pathname.startsWith(`${ROUTES.services}/`) && loc.pathname !== ROUTES.services
 
-      // 2. Delete the git credentials Secret if this is a Vibe Deploy app (best-effort)
-      if (isVibeDeploy) {
-        await kubeFetch(token, envId, `/api/v1/namespaces/${ns}/secrets/${name}-git-credentials`, { method: 'DELETE' }).catch(() => {})
-      }
+    setDeleteTarget(null)
+    setDeleteManifest(false)
+    setConfirmText('')
 
-      // 3. Delete the Kubernetes Deployment
-      const r = await kubeFetch(token, envId, `/apis/apps/v1/namespaces/${ns}/deployments/${name}`, {
-        method: 'DELETE',
-      })
-      if (!r.ok && r.status !== 404) throw new Error('HTTP ' + r.status)
-
-      // 4. Delete associated resources — best-effort, 404s silently ignored
-      await Promise.allSettled([
-        kubeFetch(token, envId, `/api/v1/namespaces/${ns}/services/${name}`, { method: 'DELETE' }),
-        kubeFetch(token, envId, `/apis/networking.k8s.io/v1/namespaces/${ns}/ingresses/${name}`, { method: 'DELETE' }),
-        ...pvcNames.map((pvcName) =>
-          kubeFetch(token, envId, `/api/v1/namespaces/${ns}/persistentvolumeclaims/${pvcName}`, { method: 'DELETE' })
-        ),
-      ])
-
-      // 5. Optionally delete git entries — run sequentially to avoid branch ref race condition
-      //    (parallel commits with the same parent SHA cause non-fast-forward errors)
-      if (isGitOps && deleteManifest) {
-        try {
-          await deleteAppManifest({ gitTargetId, branch: gitBranch, gitPath, appName: name })
-          if (isVibeDeploy && vibeSourcePath) {
-            await deleteAppManifest({ gitTargetId, branch: gitBranch, gitPath: vibeSourcePath, appName: name })
-          }
-        } catch (e) {
-          useAppStore.getState().pushToast(
-            `Deployment deleted but Git cleanup failed: ${e?.message || 'unknown error'} — check the token has write access to the repository`,
-            'warn',
-          )
-        }
-      }
-
-      useAppStore.getState().pushToast(`Deployment "${name}" deleted`, 'ok')
-      setDeleteTarget(null)
-      setDeleteManifest(false)
-      setConfirmText('')
-
-      if (
-        loc.pathname.startsWith(`${ROUTES.services}/`) &&
-        loc.pathname !== ROUTES.services
-      ) {
-        navigate(ROUTES.services, { replace: true })
-      }
-      await refreshCache(false)
-    } catch (e) {
-      useAppStore.getState().pushToast('Delete failed: ' + (e?.message || e), 'err')
-    } finally {
-      setDeleting(false)
-    }
+    void deleteApp(target, {
+      deleteManifest: alsoManifest,
+      onDeleted: () => {
+        if (wasOnDetail) navigate(ROUTES.services, { replace: true })
+      },
+    })
   }
 
   function handleCancel() {
@@ -164,17 +109,16 @@ export function DeleteModal() {
             type="button"
             className="btn btn-ghost btn-sm"
             onClick={handleCancel}
-            disabled={deleting}
           >
             Cancel
           </button>
           <button
             type="button"
             className="btn btn-danger btn-sm"
-            onClick={() => void confirm()}
-            disabled={deleting || confirmText.toLowerCase() !== 'delete'}
+            onClick={confirm}
+            disabled={confirmText.toLowerCase() !== 'delete'}
           >
-            {deleting ? 'Deleting…' : 'Delete'}
+            Delete
           </button>
         </div>
       </div>

--- a/client/src/components/DeleteModal.jsx
+++ b/client/src/components/DeleteModal.jsx
@@ -7,6 +7,7 @@ import { ROUTES } from '../lib/routes.js'
 export function DeleteModal() {
   const deleteTarget = useAppStore((s) => s.deleteTarget)
   const setDeleteTarget = useAppStore((s) => s.setDeleteTarget)
+  const [deleting, setDeleting] = useState(false)
   const [deleteManifest, setDeleteManifest] = useState(false)
   const [confirmText, setConfirmText] = useState('')
   const navigate = useNavigate()
@@ -18,28 +19,31 @@ export function DeleteModal() {
   const isVibeDeploy = Boolean(vibeSourcePath)
   const isGitOps = Boolean(gitTargetId && gitBranch && gitPath)
 
-  function confirm() {
-    // Capture everything the delete needs, then close the modal immediately.
-    // The delete runs detached (services/deleteApp) so opening a second delete
-    // right after cannot inherit this one's in-progress state (issue #44).
+  async function confirm() {
+    // Keep the modal open with a progress indicator while the delete runs.
+    // Staying open blocks a second delete from being started mid-flight, which
+    // is what previously let progress state bleed across deletes (issue #44).
     const target = deleteTarget
     const alsoManifest = deleteManifest
     const wasOnDetail =
       loc.pathname.startsWith(`${ROUTES.services}/`) && loc.pathname !== ROUTES.services
 
-    setDeleteTarget(null)
-    setDeleteManifest(false)
-    setConfirmText('')
+    setDeleting(true)
+    const ok = await deleteApp(target, { deleteManifest: alsoManifest })
+    setDeleting(false)
 
-    void deleteApp(target, {
-      deleteManifest: alsoManifest,
-      onDeleted: () => {
-        if (wasOnDetail) navigate(ROUTES.services, { replace: true })
-      },
-    })
+    if (ok) {
+      setDeleteTarget(null)
+      setDeleteManifest(false)
+      setConfirmText('')
+      if (wasOnDetail) navigate(ROUTES.services, { replace: true })
+    }
+    // On failure the modal stays open (error toast already shown) so the
+    // user can retry or cancel.
   }
 
   function handleCancel() {
+    if (deleting) return
     setDeleteTarget(null)
     setDeleteManifest(false)
     setConfirmText('')
@@ -53,54 +57,66 @@ export function DeleteModal() {
         </div>
 
         <div className="modal-body" style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-          <div>
-            Delete <strong>{name}</strong> in <strong>{ns}</strong>? Pods will be terminated. This cannot be undone.
-          </div>
-
-          <div className="field">
-            <label style={{ fontSize: 12 }}>Type <strong>delete</strong> to confirm</label>
-            <input
-              type="text"
-              value={confirmText}
-              onChange={(e) => setConfirmText(e.target.value)}
-              placeholder="delete"
-              autoComplete="off"
-              autoFocus
-            />
-          </div>
-
-          {isGitOps && (
-            <div style={{
-              background: 'var(--surface2, var(--bg2))',
-              border: '1px solid var(--border)',
-              borderRadius: 6,
-              padding: '12px 14px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 10,
-            }}>
-              <div style={{ fontSize: 12, color: 'var(--text-dim)', fontFamily: 'var(--mono)' }}>
-                This application was deployed via GitOps.
+          {deleting ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 0' }}>
+              <span className="spinner" aria-hidden="true" />
+              <div>
+                Deleting <strong>{name}</strong>
+                {deleteManifest && isGitOps ? ' and cleaning up Git' : ''}… please wait.
+              </div>
+            </div>
+          ) : (
+            <>
+              <div>
+                Delete <strong>{name}</strong> in <strong>{ns}</strong>? Pods will be terminated. This cannot be undone.
               </div>
 
-              <label style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
+              <div className="field">
+                <label style={{ fontSize: 12 }}>Type <strong>delete</strong> to confirm</label>
                 <input
-                  type="checkbox"
-                  checked={deleteManifest}
-                  onChange={(e) => setDeleteManifest(e.target.checked)}
-                  style={{ marginTop: 2, flexShrink: 0 }}
+                  type="text"
+                  value={confirmText}
+                  onChange={(e) => setConfirmText(e.target.value)}
+                  placeholder="delete"
+                  autoComplete="off"
+                  autoFocus
                 />
-                <div>
-                  <div style={{ fontSize: 13, color: 'var(--text-bright)', marginBottom: 2 }}>
-                    Also remove from Git
+              </div>
+
+              {isGitOps && (
+                <div style={{
+                  background: 'var(--surface2, var(--bg2))',
+                  border: '1px solid var(--border)',
+                  borderRadius: 6,
+                  padding: '12px 14px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 10,
+                }}>
+                  <div style={{ fontSize: 12, color: 'var(--text-dim)', fontFamily: 'var(--mono)' }}>
+                    This application was deployed via GitOps.
                   </div>
-                  <div style={{ fontSize: 11, color: 'var(--text-dim)', fontFamily: 'var(--mono)' }}>
-                    {gitPath} on {gitBranch}
-                    {isVibeDeploy && <span style={{ opacity: 0.7 }}> + source files</span>}
-                  </div>
+
+                  <label style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
+                    <input
+                      type="checkbox"
+                      checked={deleteManifest}
+                      onChange={(e) => setDeleteManifest(e.target.checked)}
+                      style={{ marginTop: 2, flexShrink: 0 }}
+                    />
+                    <div>
+                      <div style={{ fontSize: 13, color: 'var(--text-bright)', marginBottom: 2 }}>
+                        Also remove from Git
+                      </div>
+                      <div style={{ fontSize: 11, color: 'var(--text-dim)', fontFamily: 'var(--mono)' }}>
+                        {gitPath} on {gitBranch}
+                        {isVibeDeploy && <span style={{ opacity: 0.7 }}> + source files</span>}
+                      </div>
+                    </div>
+                  </label>
                 </div>
-              </label>
-            </div>
+              )}
+            </>
           )}
         </div>
 
@@ -109,16 +125,17 @@ export function DeleteModal() {
             type="button"
             className="btn btn-ghost btn-sm"
             onClick={handleCancel}
+            disabled={deleting}
           >
             Cancel
           </button>
           <button
             type="button"
             className="btn btn-danger btn-sm"
-            onClick={confirm}
-            disabled={confirmText.toLowerCase() !== 'delete'}
+            onClick={() => void confirm()}
+            disabled={deleting || confirmText.toLowerCase() !== 'delete'}
           >
-            Delete
+            {deleting ? 'Deleting…' : 'Delete'}
           </button>
         </div>
       </div>

--- a/client/src/components/GitTargetForm.jsx
+++ b/client/src/components/GitTargetForm.jsx
@@ -127,6 +127,7 @@ export function GitTargetForm({ initial, onSaved, onCancel }) {
             <div className="hint">
               Username required for private repos and fine-grained PATs. For GitHub classic PATs use <code>oauth2</code>.
             </div>
+            <TokenScopeNotice provider={payload.provider} />
             <div className="hint" style={{ marginTop: 4 }}>
               This token is stored encrypted and is also passed to Portainer when creating a GitOps stack, so Portainer can poll the repository for changes.
             </div>
@@ -228,6 +229,36 @@ export function GitTargetForm({ initial, onSaved, onCancel }) {
       </div>
     </div>
   )
+}
+
+/**
+ * Minimum PAT scope guidance per provider. Advisory only — there is no reliable
+ * cross-provider API to introspect a token's granted scopes before use, so we
+ * state the required scope rather than validating it. See issue #33.
+ */
+function TokenScopeNotice({ provider }) {
+  let body
+  if (provider === 'gitlab') {
+    body = (
+      <>Requires a token with the <code>api</code> scope. Narrower combinations such as{' '}
+      <code>read_api</code> + <code>write_repository</code> pass GitLab's own checks but fail
+      when Portainer-Run writes manifests and creates the GitOps stack.</>
+    )
+  } else if (provider === 'github') {
+    body = (
+      <>Classic tokens require the <code>repo</code> scope. Fine-grained tokens require{' '}
+      <b>Contents</b> read and write permission on the target repository.</>
+    )
+  } else if (provider === 'gitea') {
+    body = (
+      <>Requires a token with <code>write:repository</code> (repository read and write) permission.</>
+    )
+  } else {
+    body = (
+      <>Provide a token with repository read and write permission so manifests can be committed.</>
+    )
+  }
+  return <div className="hint" style={{ marginTop: 4 }}>{body}</div>
 }
 
 function Field({ label, value, onChange, placeholder, type = 'text', mono = false }) {

--- a/client/src/components/MainLayout.jsx
+++ b/client/src/components/MainLayout.jsx
@@ -115,6 +115,7 @@ export function MainLayout() {
   const disabledEnvs = useAppStore((s) => s.disabledEnvs)
   const isAdmin = useAppStore((s) => s.isAdmin)
   const isAiAvailable = useAppStore((s) => s.isAiAvailable)
+  const version = useAppStore((s) => s.version)
   const setChatOpen = useAppStore((s) => s.setChatOpen)
   const chatOpen = useAppStore((s) => s.chatOpen)
   const isMobile = useIsMobile()
@@ -220,6 +221,7 @@ export function MainLayout() {
         {!isMobile && (
           <nav>
             <NavLinks isAdmin={isAdmin} />
+            <div className="sidebar-version" title="Portainer-Run release">{version}</div>
           </nav>
         )}
         <div className="content">

--- a/client/src/components/MainLayout.jsx
+++ b/client/src/components/MainLayout.jsx
@@ -221,7 +221,7 @@ export function MainLayout() {
         {!isMobile && (
           <nav>
             <NavLinks isAdmin={isAdmin} />
-            <div className="sidebar-version" title="Portainer-Run release">{version}</div>
+            <div className="sidebar-version" title="Portainer-Run release">Portainer-Run {version}</div>
           </nav>
         )}
         <div className="content">

--- a/client/src/components/VibeDeploy.jsx
+++ b/client/src/components/VibeDeploy.jsx
@@ -133,7 +133,11 @@ function parseEnvExample(text) {
   return vars
 }
 
-const SECRET_PATTERN = /SECRET|KEY|TOKEN|PASSWORD|PASS|AUTH|CREDENTIAL/i
+// Keys whose names imply a secret value. Kept in sync with the server's
+// isSensitiveEnvKey in routes/vibe.js — matching values are stored in a
+// Kubernetes Secret instead of being committed to git (issue #38).
+const SECRET_PATTERN =
+  /(^|[^A-Z])(PASSWORD|PASSWD|PASS|SECRET|TOKEN|API[_-]?KEY|APIKEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIALS?|AUTH|DSN|CONNECTION[_-]?STRING|CERT|SIGNING)([^A-Z]|$)/i
 
 // ---------------------------------------------------------------------------
 // Step indicator
@@ -1124,7 +1128,7 @@ export function VibeDeploy() {
                 onClick={() => setEnvVars((prev) => [...prev, { key: '', value: '', custom: true }])}>
                 + Add variable
               </button>
-              <div className="hint">Values marked with •••• are treated as sensitive and hidden from view.</div>
+              <div className="hint">Values whose name looks sensitive (password, token, key, secret, and similar) are hidden here, stored in a Kubernetes Secret in your project space, and are never written into the git repository. Other values are committed as plain configuration.</div>
               <div className="form-actions">
                 <button type="button" className="btn btn-ghost" onClick={() => setStep(1)}>← Back</button>
                 <button type="button" className="btn btn-primary" onClick={confirmEnvVars}>
@@ -1149,11 +1153,29 @@ export function VibeDeploy() {
                   <div className="hint">Lowercase, alphanumeric and hyphens</div>
                 </div>
               </div>
+              {(() => {
+                const availableEnvs = environments.filter((e) => !isEnvDisabled({ disabledEnvs }, e.Id))
+                const singleEnv = availableEnvs.length === 1
+                const singleNs = nsList.length === 1 && !nsLoading && !manualNs
+                // When the user has exactly one environment and one project space,
+                // there is nothing to choose. Hide the infrastructure selectors
+                // entirely — non-technical users should not have to reason about
+                // environments or namespaces (per user feedback). The values are
+                // auto-selected elsewhere, so deploy still has everything it needs.
+                if (singleEnv && singleNs) {
+                  return (
+                    <div className="hint" style={{ marginBottom: 4 }}>
+                      Deploying to <strong style={{ color: 'var(--text-bright)' }}>{availableEnvs[0].Name}</strong>
+                      {' / '}
+                      <strong style={{ color: 'var(--text-bright)' }}>{nsList[0]}</strong>
+                    </div>
+                  )
+                }
+                return (
               <div className="frow">
                 <div className="field">
                   <label>Deployment target</label>
                   {(() => {
-                    const availableEnvs = environments.filter((e) => !isEnvDisabled({ disabledEnvs }, e.Id))
                     const locked = availableEnvs.length === 1
                     return locked ? (
                       <div style={{
@@ -1214,6 +1236,8 @@ export function VibeDeploy() {
                   <div className="hint">Project space must already exist in the target</div>
                 </div>
               </div>
+                )
+              })()}
               {perms && (!perms.canDeploy || !perms.canCreatePvc) && (
                 <div style={{
                   padding: '12px 14px', background: 'rgba(239,68,68,0.08)',

--- a/client/src/components/serviceDetail/VibeEditTab.jsx
+++ b/client/src/components/serviceDetail/VibeEditTab.jsx
@@ -188,6 +188,8 @@ export default function VibeEditTab({ d, envId, namespace, name, gitOpsInfo, onS
           gitTargetId: gitOpsInfo.gitTargetId,
           branch: gitOpsInfo.gitBranch,
           gitPath,
+          envId,
+          ns: namespace,
           envVars: envVars.filter((v) => v.key && v.key.trim()),
         }),
       })

--- a/client/src/lib/gitTargets.js
+++ b/client/src/lib/gitTargets.js
@@ -105,3 +105,14 @@ export function deleteAppManifest({ gitTargetId, branch, gitPath, appName }) {
     body: JSON.stringify({ gitTargetId, branch, gitPath, appName }),
   })
 }
+
+/**
+ * Remove multiple paths (manifest file + source directory) in a single commit.
+ * Avoids the non-fast-forward race of two sequential delete commits.
+ */
+export function deleteAppPaths({ gitTargetId, branch, paths, appName }) {
+  return serverFetch('/api/vibe/delete-manifest', {
+    method: 'POST',
+    body: JSON.stringify({ gitTargetId, branch, paths, appName }),
+  })
+}

--- a/client/src/services/config.js
+++ b/client/src/services/config.js
@@ -19,6 +19,7 @@ export async function loadServerConfig() {
     )
     st().setAi(!!d.aiAvailable, d.aiProvider || 'anthropic', d.baseDomain || '')
     if (d.configNamespace) st().setConfigNamespace(d.configNamespace)
+    st().setVersion(d.version || 'dev')
   } catch (e) {
     st().setPortainerFromServer(false)
     st().setServerLabel('API proxy not reachable — is the portainer-run server running?')

--- a/client/src/services/deleteApp.js
+++ b/client/src/services/deleteApp.js
@@ -9,17 +9,17 @@ export function appDeleteKey(envId, ns, name) {
 }
 
 /**
- * Delete a deployment and its associated resources. Runs detached from the
- * confirm modal so a second delete can be started without the first's progress
- * state bleeding into it (issue #44). Progress is tracked in the store under
- * deletingApps keyed by app, and all user feedback is via toasts.
+ * Delete a deployment and its associated resources. Awaited by the confirm
+ * modal, which stays open with a progress indicator until this resolves
+ * (issue #44). Progress is also tracked in the store under deletingApps keyed
+ * by app, as a guard against a duplicate delete of the same app.
  *
  * @param {object} target  { envId, ns, name, gitTargetId?, gitBranch?, gitPath?, vibeSourcePath? }
  * @param {object} [opts]
  * @param {boolean} [opts.deleteManifest]  also remove GitOps manifest/source from git
- * @param {() => void} [opts.onDeleted]    called once after a successful delete
+ * @returns {Promise<boolean>}  true if the deployment was deleted, false on failure
  */
-export async function deleteApp(target, { deleteManifest = false, onDeleted } = {}) {
+export async function deleteApp(target, { deleteManifest = false } = {}) {
   const { envId, ns, name, gitTargetId, gitBranch, gitPath, vibeSourcePath } = target
   const isVibeDeploy = Boolean(vibeSourcePath)
   const isGitOps = Boolean(gitTargetId && gitBranch && gitPath)
@@ -29,7 +29,7 @@ export async function deleteApp(target, { deleteManifest = false, onDeleted } = 
   const key = appDeleteKey(envId, ns, name)
 
   // Guard against re-triggering a delete already in flight for the same app.
-  if (st().deletingApps[key]) return
+  if (st().deletingApps[key]) return false
   st().markAppDeleting(key)
 
   try {
@@ -86,10 +86,11 @@ export async function deleteApp(target, { deleteManifest = false, onDeleted } = 
     }
 
     st().pushToast(`Deployment "${name}" deleted`, 'ok')
-    if (typeof onDeleted === 'function') onDeleted()
     await refreshCache(false)
+    return true
   } catch (e) {
     st().pushToast(`Delete failed for "${name}": ` + (e?.message || e), 'err')
+    return false
   } finally {
     st().clearAppDeleting(key)
   }

--- a/client/src/services/deleteApp.js
+++ b/client/src/services/deleteApp.js
@@ -1,6 +1,6 @@
 import { kubeFetch } from '../lib/api.js'
 import { refreshCache } from './refreshDeployments.js'
-import { deleteAppManifest } from '../lib/gitTargets.js'
+import { deleteAppPaths } from '../lib/gitTargets.js'
 import { useAppStore } from '../store/useAppStore.js'
 
 /** Stable key for an app's in-flight delete state. */
@@ -69,14 +69,14 @@ export async function deleteApp(target, { deleteManifest = false } = {}) {
       ),
     ])
 
-    // 5. Optionally delete git entries — run sequentially to avoid branch ref race
-    //    (parallel commits with the same parent SHA cause non-fast-forward errors)
+    // 5. Optionally delete git entries — manifest file and source directory
+    //    removed in a SINGLE commit to avoid a non-fast-forward race between
+    //    two sequential commits against the same branch.
     if (isGitOps && deleteManifest) {
       try {
-        await deleteAppManifest({ gitTargetId, branch: gitBranch, gitPath, appName: name })
-        if (isVibeDeploy && vibeSourcePath) {
-          await deleteAppManifest({ gitTargetId, branch: gitBranch, gitPath: vibeSourcePath, appName: name })
-        }
+        const paths = [gitPath]
+        if (isVibeDeploy && vibeSourcePath) paths.push(vibeSourcePath)
+        await deleteAppPaths({ gitTargetId, branch: gitBranch, paths, appName: name })
       } catch (e) {
         st().pushToast(
           `Deployment deleted but Git cleanup failed: ${e?.message || 'unknown error'} — check the token has write access to the repository`,

--- a/client/src/services/deleteApp.js
+++ b/client/src/services/deleteApp.js
@@ -1,0 +1,96 @@
+import { kubeFetch } from '../lib/api.js'
+import { refreshCache } from './refreshDeployments.js'
+import { deleteAppManifest } from '../lib/gitTargets.js'
+import { useAppStore } from '../store/useAppStore.js'
+
+/** Stable key for an app's in-flight delete state. */
+export function appDeleteKey(envId, ns, name) {
+  return `${envId}:${ns}:${name}`
+}
+
+/**
+ * Delete a deployment and its associated resources. Runs detached from the
+ * confirm modal so a second delete can be started without the first's progress
+ * state bleeding into it (issue #44). Progress is tracked in the store under
+ * deletingApps keyed by app, and all user feedback is via toasts.
+ *
+ * @param {object} target  { envId, ns, name, gitTargetId?, gitBranch?, gitPath?, vibeSourcePath? }
+ * @param {object} [opts]
+ * @param {boolean} [opts.deleteManifest]  also remove GitOps manifest/source from git
+ * @param {() => void} [opts.onDeleted]    called once after a successful delete
+ */
+export async function deleteApp(target, { deleteManifest = false, onDeleted } = {}) {
+  const { envId, ns, name, gitTargetId, gitBranch, gitPath, vibeSourcePath } = target
+  const isVibeDeploy = Boolean(vibeSourcePath)
+  const isGitOps = Boolean(gitTargetId && gitBranch && gitPath)
+
+  const st = useAppStore.getState
+  const token = st().token
+  const key = appDeleteKey(envId, ns, name)
+
+  // Guard against re-triggering a delete already in flight for the same app.
+  if (st().deletingApps[key]) return
+  st().markAppDeleting(key)
+
+  try {
+    // 1. Read Deployment first so we can find all PVC names from spec.volumes
+    let pvcNames = [name] // fallback: assume PVC shares the deployment name
+    try {
+      const depRes = await kubeFetch(token, envId, `/apis/apps/v1/namespaces/${ns}/deployments/${name}`)
+      if (depRes.ok) {
+        const dep = await depRes.json()
+        const vols = dep?.spec?.template?.spec?.volumes || []
+        const fromSpec = vols
+          .filter((v) => v.persistentVolumeClaim?.claimName)
+          .map((v) => v.persistentVolumeClaim.claimName)
+        if (fromSpec.length > 0) pvcNames = fromSpec
+      }
+    } catch { /* non-fatal — fall through to name-based fallback */ }
+
+    // 2. Delete the git credentials Secret if this is a Vibe Deploy app (best-effort)
+    if (isVibeDeploy) {
+      await kubeFetch(token, envId, `/api/v1/namespaces/${ns}/secrets/${name}-git-credentials`, { method: 'DELETE' }).catch(() => {})
+      // App secrets Secret, if one was created for sensitive env vars (issue #38)
+      await kubeFetch(token, envId, `/api/v1/namespaces/${ns}/secrets/${name}-app-secrets`, { method: 'DELETE' }).catch(() => {})
+    }
+
+    // 3. Delete the Kubernetes Deployment
+    const r = await kubeFetch(token, envId, `/apis/apps/v1/namespaces/${ns}/deployments/${name}`, {
+      method: 'DELETE',
+    })
+    if (!r.ok && r.status !== 404) throw new Error('HTTP ' + r.status)
+
+    // 4. Delete associated resources — best-effort, 404s silently ignored
+    await Promise.allSettled([
+      kubeFetch(token, envId, `/api/v1/namespaces/${ns}/services/${name}`, { method: 'DELETE' }),
+      kubeFetch(token, envId, `/apis/networking.k8s.io/v1/namespaces/${ns}/ingresses/${name}`, { method: 'DELETE' }),
+      ...pvcNames.map((pvcName) =>
+        kubeFetch(token, envId, `/api/v1/namespaces/${ns}/persistentvolumeclaims/${pvcName}`, { method: 'DELETE' })
+      ),
+    ])
+
+    // 5. Optionally delete git entries — run sequentially to avoid branch ref race
+    //    (parallel commits with the same parent SHA cause non-fast-forward errors)
+    if (isGitOps && deleteManifest) {
+      try {
+        await deleteAppManifest({ gitTargetId, branch: gitBranch, gitPath, appName: name })
+        if (isVibeDeploy && vibeSourcePath) {
+          await deleteAppManifest({ gitTargetId, branch: gitBranch, gitPath: vibeSourcePath, appName: name })
+        }
+      } catch (e) {
+        st().pushToast(
+          `Deployment deleted but Git cleanup failed: ${e?.message || 'unknown error'} — check the token has write access to the repository`,
+          'warn',
+        )
+      }
+    }
+
+    st().pushToast(`Deployment "${name}" deleted`, 'ok')
+    if (typeof onDeleted === 'function') onDeleted()
+    await refreshCache(false)
+  } catch (e) {
+    st().pushToast(`Delete failed for "${name}": ` + (e?.message || e), 'err')
+  } finally {
+    st().clearAppDeleting(key)
+  }
+}

--- a/client/src/store/useAppStore.js
+++ b/client/src/store/useAppStore.js
@@ -22,6 +22,7 @@ export const useAppStore = create((set, get) => ({
   aiProvider: 'anthropic',
   baseDomain: '',
   configNamespace: 'kube-system',
+  version: 'dev',
   /** @type {Record<string, { reason?: string, disabledAt?: string }>} */
   disabledEnvs: {},
   cache: { ...initialCache },
@@ -40,6 +41,10 @@ export const useAppStore = create((set, get) => ({
 
   /** @type {null | { envId: string, ns: string, name: string }} */
   deleteTarget: null,
+
+  /** In-flight deletes keyed by `${envId}:${ns}:${name}` — survives the modal closing. */
+  /** @type {Record<string, true>} */
+  deletingApps: {},
 
   /** @type {null | { envId: string, ns: string, name: string }} */
   restartTarget: null,
@@ -62,6 +67,7 @@ export const useAppStore = create((set, get) => ({
   setAi: (isAiAvailable, aiProvider, baseDomain) =>
     set({ isAiAvailable, aiProvider, baseDomain: baseDomain || '' }),
   setConfigNamespace: (v) => set({ configNamespace: v || 'kube-system' }),
+  setVersion: (v) => set({ version: v || 'dev' }),
   setDisabledEnvs: (disabledEnvs) => set({ disabledEnvs }),
   setCache: (updater) =>
     set((s) => (typeof updater === 'function' ? { cache: updater(s.cache) } : { cache: updater })),
@@ -83,6 +89,13 @@ export const useAppStore = create((set, get) => ({
   patchEnvPermissions: (envId, namespace, perms) =>
     set((s) => ({ envPermissions: { ...s.envPermissions, [`${envId}:${namespace}`]: perms } })),
   setDeleteTarget: (deleteTarget) => set({ deleteTarget }),
+  markAppDeleting: (key) => set((s) => ({ deletingApps: { ...s.deletingApps, [key]: true } })),
+  clearAppDeleting: (key) =>
+    set((s) => {
+      const next = { ...s.deletingApps }
+      delete next[key]
+      return { deletingApps: next }
+    }),
   setRestartTarget: (restartTarget) => set({ restartTarget }),
   setChatOpen: (chatOpen) => {
     if (typeof document !== 'undefined') {

--- a/server/config.js
+++ b/server/config.js
@@ -36,6 +36,9 @@ export const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || ''
 export const BASE_DOMAIN  = process.env.BASE_DOMAIN  || ''
 export const GATEWAY_URL  = (process.env.GATEWAY_URL || '').replace(/\/$/, '')
 
+/** Release version, baked in at Docker build time. 'dev' for local/non-release builds. */
+export const VERSION = process.env.PORTAINER_RUN_VERSION || 'dev'
+
 function resolveConfigNamespace() {
   // When running in Kubernetes, the pod's own namespace is mounted at this path automatically.
   try {

--- a/server/handler.js
+++ b/server/handler.js
@@ -8,6 +8,7 @@ import {
   OPENAI_KEY,
   PORTAINER_URL,
   CONFIG_NAMESPACE,
+  VERSION,
 } from './config.js'
 import { handleCache } from './cache.js'
 import { handleEnvStatus } from './env-status.js'
@@ -43,6 +44,7 @@ export async function handleRequest(req, res) {
         aiProvider: AI_PROVIDER,
         baseDomain: BASE_DOMAIN,
         configNamespace: CONFIG_NAMESPACE,
+        version: VERSION,
       }),
     )
     return

--- a/server/lib/manifestSerialize.js
+++ b/server/lib/manifestSerialize.js
@@ -1,5 +1,16 @@
 import yaml from 'js-yaml'
 
+// Pod Security Standards (issue #39). Kept in sync with the vibe deploy path in
+// routes/vibe.js. Applied to every container in the pod plus the pod itself.
+const CONTAINER_SECURITY_CONTEXT = {
+  allowPrivilegeEscalation: false,
+  capabilities: { drop: ['ALL'] },
+  seccompProfile: { type: 'RuntimeDefault' },
+}
+const POD_SECURITY_CONTEXT = {
+  seccompProfile: { type: 'RuntimeDefault' },
+}
+
 /**
  * Normalize a Kubernetes quantity string.
  * Converts common mistakes to valid suffixes and validates the result.
@@ -105,6 +116,9 @@ export function buildManifests({
         if (!r.limits.cpu && !r.limits.memory) delete spec.resources.limits
       }
     }
+    // Pod Security Standards (issue #39): harden every container, preserving
+    // any securityContext keys already present on the spec.
+    spec.securityContext = { ...CONTAINER_SECURITY_CONTEXT, ...(spec.securityContext || {}) }
     return spec
   })
   const clonedIdToSpec = new Map(containerRowIds.map((id, i) => [id, clonedSpecs[i]]))
@@ -164,6 +178,8 @@ export function buildManifests({
       template: {
         metadata: { labels: { app: appName, 'managed-by': 'portainer-run' } },
         spec: {
+          securityContext: POD_SECURITY_CONTEXT,
+          automountServiceAccountToken: false,
           containers: clonedSpecs,
           ...(podVolumes.length ? { volumes: podVolumes } : {}),
         },

--- a/server/proxy/git.js
+++ b/server/proxy/git.js
@@ -388,6 +388,142 @@ export async function deleteDirectory(payload, branch, dirPath, message) {
 }
 
 /**
+ * Delete multiple paths (a mix of files and directories) in a SINGLE commit.
+ *
+ * Doing file + directory removals as separate commits races GitHub's
+ * read-after-write ref propagation: the second operation can read a stale
+ * branch SHA and fail the ref update with a non-fast-forward error. Removing
+ * everything in one commit closes that window entirely.
+ *
+ * @param {object} payload
+ * @param {string} branch
+ * @param {string[]} paths   file paths and/or directory paths to remove
+ * @param {string} message
+ */
+export async function deletePaths(payload, branch, paths, message) {
+  const clean = (paths || []).map((p) => String(p || '').replace(/\/+$/, '')).filter(Boolean)
+  if (clean.length === 0) return { ok: true, deleted: 0 }
+  const { provider } = payload
+  if (provider === 'github') return deletePathsGitHub(payload, branch, clean, message)
+  if (provider === 'gitlab') return deletePathsGitLab(payload, branch, clean, message)
+  return deletePathsGitea(payload, branch, clean, message)
+}
+
+/** True when a blob path should be removed given the requested paths. */
+function matchesAnyPath(blobPath, paths) {
+  for (const p of paths) {
+    // Exact file match, or any blob under a directory prefix.
+    if (blobPath === p || blobPath.startsWith(p + '/')) return true
+  }
+  return false
+}
+
+/**
+ * GitHub: remove all requested files and directory subtrees in one commit
+ * using the Git Data API (ref → commit → tree → new tree → new commit → ref).
+ */
+async function deletePathsGitHub(payload, branch, paths, message) {
+  const { repo } = payload
+  const headers = buildHeaders(payload)
+  const base = githubApiBase(payload)
+
+  const refData = await request('GET', `${base}/repos/${repo}/git/ref/heads/${branch}`, headers)
+  const commitSha = refData.object.sha
+  const commitData = await request('GET', `${base}/repos/${repo}/git/commits/${commitSha}`, headers)
+  const treeSha = commitData.tree.sha
+  const treeData = await request('GET', `${base}/repos/${repo}/git/trees/${treeSha}?recursive=1`, headers)
+
+  const allBlobs = treeData.tree.filter((e) => e.type === 'blob')
+  const remaining = allBlobs.filter((entry) => !matchesAnyPath(entry.path, paths))
+  if (remaining.length === allBlobs.length) return { ok: true, deleted: 0 }
+
+  const newTree = await request('POST', `${base}/repos/${repo}/git/trees`, headers, {
+    tree: remaining.map((e) => ({ path: e.path, mode: e.mode, type: e.type, sha: e.sha })),
+  })
+  const newCommit = await request('POST', `${base}/repos/${repo}/git/commits`, headers, {
+    message,
+    tree: newTree.sha,
+    parents: [commitSha],
+  })
+  await request('PATCH', `${base}/repos/${repo}/git/refs/heads/${branch}`, headers, {
+    sha: newCommit.sha,
+    force: false,
+  })
+  return { ok: true, deleted: allBlobs.length - remaining.length }
+}
+
+/**
+ * GitLab: one commits API call with a delete action per resolved file. Files
+ * are resolved by listing each directory path recursively; explicit file paths
+ * are included directly.
+ */
+async function deletePathsGitLab(payload, branch, paths, message) {
+  const { repo } = payload
+  const base = gitlabApiBase(payload)
+  const encoded = encodeURIComponent(repo)
+  const headers = buildHeaders(payload)
+
+  const fileSet = new Set()
+  for (const p of paths) {
+    // Try to list p as a directory; if it yields blobs, those are the targets.
+    let listed = []
+    try {
+      listed = await request('GET',
+        `${base}/api/v4/projects/${encoded}/repository/tree?path=${encodeURIComponent(p)}&ref=${branch}&recursive=true&per_page=100`,
+        headers)
+    } catch { listed = [] }
+    const blobs = (Array.isArray(listed) ? listed : []).filter((i) => i.type === 'blob')
+    if (blobs.length > 0) {
+      for (const b of blobs) fileSet.add(b.path)
+    } else {
+      // Not a directory (or empty) — treat as a single file path.
+      fileSet.add(p)
+    }
+  }
+  if (fileSet.size === 0) return { ok: true, deleted: 0 }
+
+  await request('POST', `${base}/api/v4/projects/${encoded}/repository/commits`, headers, {
+    branch,
+    commit_message: message,
+    actions: [...fileSet].map((file_path) => ({ action: 'delete', file_path })),
+  })
+  return { ok: true, deleted: fileSet.size }
+}
+
+/**
+ * Gitea: same single-commit Git Data API approach as GitHub.
+ */
+async function deletePathsGitea(payload, branch, paths, message) {
+  const { repo, url: baseUrl } = payload
+  const base = baseUrl || ''
+  const headers = buildHeaders(payload)
+
+  const refData = await request('GET', `${base}/api/v1/repos/${repo}/branches/${branch}`, headers)
+  const commitSha = refData.commit.id
+  const commitData = await request('GET', `${base}/api/v1/repos/${repo}/git/commits/${commitSha}`, headers)
+  const treeSha = commitData.tree?.sha || commitData.commit?.tree?.sha
+  const treeData = await request('GET', `${base}/api/v1/repos/${repo}/git/trees/${treeSha}?recursive=true`, headers)
+
+  const allBlobs = (treeData.tree || []).filter((e) => e.type === 'blob')
+  const remaining = allBlobs.filter((entry) => !matchesAnyPath(entry.path, paths))
+  if (remaining.length === allBlobs.length) return { ok: true, deleted: 0 }
+
+  const newTree = await request('POST', `${base}/api/v1/repos/${repo}/git/trees`, headers, {
+    tree: remaining.map((e) => ({ path: e.path, mode: e.mode, type: e.type, sha: e.sha })),
+  })
+  const newCommit = await request('POST', `${base}/api/v1/repos/${repo}/git/commits`, headers, {
+    message,
+    tree: newTree.sha,
+    parents: [commitSha],
+  })
+  await request('PATCH', `${base}/api/v1/repos/${repo}/git/refs/heads/${branch}`, headers, {
+    sha: newCommit.sha,
+    force: false,
+  })
+  return { ok: true, deleted: allBlobs.length - remaining.length }
+}
+
+/**
  * GitHub: delete a directory in a single commit using the Git Data API tree approach.
  * Fetches the full recursive tree, filters out all entries under dirPath,
  * creates a new tree and commit, then updates the branch ref.

--- a/server/routes/vibe.js
+++ b/server/routes/vibe.js
@@ -185,6 +185,74 @@ const INIT_INSTALL_RESOURCES = {
   limits: { cpu: '1', memory: '2Gi' },
 }
 
+// --- Pod Security Standards (issue #39) ---------------------------------------
+// Applied to the app container and every init container. We harden with the
+// flags that are safe across the images used here (alpine/git, busybox, and
+// arbitrary user runtime images that typically start as root and write into the
+// mounted PV): drop all capabilities, block privilege escalation, and pin the
+// default seccomp profile. We deliberately do NOT force runAsNonRoot or
+// readOnlyRootFilesystem, because the sync/install/env init steps and many
+// vibe-built images legitimately need to write to the filesystem and run as
+// their image's default user. This matches the Kubernetes "baseline"/restricted
+// intent without breaking the deploy flow.
+const CONTAINER_SECURITY_CONTEXT = {
+  allowPrivilegeEscalation: false,
+  capabilities: { drop: ['ALL'] },
+  seccompProfile: { type: 'RuntimeDefault' },
+}
+
+// Pod-level context: never mount the service account token (the workloads
+// deployed here never call the Kubernetes API) and pin the default seccomp
+// profile at the pod level so it is inherited by anything without its own.
+const POD_SECURITY_CONTEXT = {
+  seccompProfile: { type: 'RuntimeDefault' },
+}
+
+/** Attach the hardened container securityContext, preserving any existing keys. */
+function harden(container) {
+  if (!container || typeof container !== 'object') return container
+  container.securityContext = {
+    ...CONTAINER_SECURITY_CONTEXT,
+    ...(container.securityContext || {}),
+  }
+  return container
+}
+
+// --- Sensitive ENV detection (issue #38) --------------------------------------
+// Env keys whose names imply a secret must not be written into the committed
+// manifest (the vibe-env init container embeds .env values in plaintext inside
+// the Deployment YAML). Matching keys are instead stored in a Kubernetes Secret
+// and referenced with secretKeyRef, so the value never touches git.
+//
+// Word-boundary matching on common secret-bearing tokens. Case-insensitive.
+const SENSITIVE_ENV_PATTERN =
+  /(^|[^A-Z])(PASSWORD|PASSWD|PASS|SECRET|TOKEN|API[_-]?KEY|APIKEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIALS?|AUTH|DSN|CONNECTION[_-]?STRING|CERT|SIGNING)([^A-Z]|$)/i
+
+/** True when an env key name implies its value is sensitive. */
+export function isSensitiveEnvKey(key) {
+  return SENSITIVE_ENV_PATTERN.test(String(key || ''))
+}
+
+/** The Kubernetes Secret name that holds an app's sensitive env values. */
+function appSecretName(safeApp) {
+  return `${safeApp}-app-secrets`
+}
+
+/**
+ * Split env vars into plaintext (safe to commit) and sensitive (stored in a
+ * Secret). Returns { plain: [{key,value}], sensitive: [{key,value}] }.
+ */
+function splitSensitiveEnv(envVars) {
+  const plain = []
+  const sensitive = []
+  for (const v of envVars || []) {
+    if (!v || !v.key) continue
+    if (isSensitiveEnvKey(v.key)) sensitive.push(v)
+    else plain.push(v)
+  }
+  return { plain, sensitive }
+}
+
 function buildVibeManifests({
   appName,
   ns,
@@ -231,10 +299,23 @@ function buildVibeManifests({
     },
   }
 
-  // Build env array for the main container
-  const containerEnv = (envVars || [])
-    .filter((v) => v.key)
-    .map((v) => ({ name: v.key, value: v.value }))
+  // Split env into plaintext (safe to commit) and sensitive (stored in a Secret).
+  // Sensitive values are referenced via secretKeyRef so they never appear in the
+  // committed manifest. See issue #38.
+  const { plain: plainEnv, sensitive: sensitiveEnv } = splitSensitiveEnv(envVars)
+  const hasSecrets = sensitiveEnv.length > 0
+  const secretForApp = appSecretName(safeApp)
+
+  // Build env array for the main container:
+  //  - plaintext vars inline
+  //  - sensitive vars sourced from the app-secrets Secret
+  const containerEnv = [
+    ...plainEnv.map((v) => ({ name: v.key, value: v.value })),
+    ...sensitiveEnv.map((v) => ({
+      name: v.key,
+      valueFrom: { secretKeyRef: { name: secretForApp, key: v.key } },
+    })),
+  ]
 
   // Init container: clones/syncs source from git into the PV
   // Two init containers: first clones and copies source; second writes .env if needed.
@@ -289,11 +370,12 @@ function buildVibeManifests({
     })
   }
 
-  // Init 3: write .env if envVars present
-  if (containerEnv.length > 0) {
-    const envFileContent = (envVars || [])
-      .filter((v) => v.key)
-      .map((v) => `${v.key}=${v.value.replace(/\n/g, '\\n')}`)
+  // Init 3: write .env with the NON-sensitive vars only.
+  // Sensitive values are delivered to the container via secretKeyRef (process.env)
+  // and are deliberately never written into this committed init command. See #38.
+  if (plainEnv.length > 0) {
+    const envFileContent = plainEnv
+      .map((v) => `${v.key}=${String(v.value ?? '').replace(/\n/g, '\\n')}`)
       .join('\n')
     // Write .env using a busybox printf — escape single quotes in values
     const escapedContent = envFileContent.replace(/'/g, "'\\''")
@@ -325,6 +407,11 @@ function buildVibeManifests({
   // Remove undefined command
   if (!mainContainer.command) delete mainContainer.command
 
+  // Pod Security Standards (issue #39): harden the app container and every
+  // init container, and lock down the pod (no service account token).
+  harden(mainContainer)
+  for (const ic of initContainers) harden(ic)
+
   // Deployment
   const deployment = {
     apiVersion: 'apps/v1',
@@ -336,6 +423,8 @@ function buildVibeManifests({
       template: {
         metadata: { labels: { app: safeApp, 'managed-by': 'portainer-run' } },
         spec: {
+          securityContext: POD_SECURITY_CONTEXT,
+          automountServiceAccountToken: false,
           initContainers,
           containers: [mainContainer],
           volumes: [{ name: 'app-data', persistentVolumeClaim: { claimName: `${safeApp}-data` } }],
@@ -566,6 +655,19 @@ async function handleVibeDeploy(req, res) {
           username: initCredUsername || 'oauth2',
           token: initCredToken,
         },
+      })
+    }
+
+    // 5b. Create the app-secrets Secret for any sensitive env vars (issue #38).
+    //     These values are referenced by the Deployment via secretKeyRef and are
+    //     never written into the committed manifest.
+    const { sensitive: sensitiveEnv } = splitSensitiveEnv(vibeParams.envVars || [])
+    if (sensitiveEnv.length > 0) {
+      await createKubernetesSecret(req, {
+        envId,
+        ns,
+        name: `${safeApp}-app-secrets`,
+        data: Object.fromEntries(sensitiveEnv.map((v) => [v.key, String(v.value ?? '')])),
       })
     }
 
@@ -1044,7 +1146,7 @@ async function handleVibeUpdateEnv(req, res) {
   const data = parseJson(body)
   if (!data) return json(res, 400, { error: 'Invalid request body' })
 
-  const { gitTargetId, branch, gitPath, envVars } = data
+  const { gitTargetId, branch, gitPath, envVars, envId, ns } = data
   if (!gitTargetId || !branch || !gitPath) {
     return json(res, 400, { error: 'gitTargetId, branch and gitPath are required' })
   }
@@ -1074,40 +1176,71 @@ async function handleVibeUpdateEnv(req, res) {
       .filter((v) => v && typeof v.key === 'string' && v.key.trim())
       .map((v) => ({ key: v.key.trim(), value: String(v.value ?? '') }))
 
-    // 1. Container env array.
-    if (cleaned.length > 0) {
-      container.env = cleaned.map((v) => ({ name: v.key, value: v.value }))
+    // Split into plaintext (committed) and sensitive (Secret-backed). See #38.
+    const { plain: plainEnv, sensitive: sensitiveEnv } = splitSensitiveEnv(cleaned)
+    const safeApp = sanitizeStackName(deployment.metadata?.name || 'app')
+    const secretForApp = `${safeApp}-app-secrets`
+
+    // 1. Container env array: plaintext inline, sensitive via secretKeyRef.
+    const nextEnv = [
+      ...plainEnv.map((v) => ({ name: v.key, value: v.value })),
+      ...sensitiveEnv.map((v) => ({
+        name: v.key,
+        valueFrom: { secretKeyRef: { name: secretForApp, key: v.key } },
+      })),
+    ]
+    if (nextEnv.length > 0) {
+      container.env = nextEnv
     } else {
       delete container.env
     }
 
-    // 2. vibe-env init container — writes the .env file into the volume.
-    //    Regenerated wholesale to mirror the deploy path exactly.
+    // 2. vibe-env init container — writes ONLY the plaintext vars into .env.
+    //    Sensitive values arrive via secretKeyRef and never touch the manifest.
     const workDir = container.workingDir || '/app'
     podSpec.initContainers = (podSpec.initContainers || []).filter((c) => c.name !== 'vibe-env')
-    if (cleaned.length > 0) {
-      const envFileContent = cleaned
+    if (plainEnv.length > 0) {
+      const envFileContent = plainEnv
         .map((v) => `${v.key}=${v.value.replace(/\n/g, '\\n')}`)
         .join('\n')
       const escaped = envFileContent.replace(/'/g, "'\\''")
-      podSpec.initContainers.push({
+      podSpec.initContainers.push(harden({
         name: 'vibe-env',
         image: 'busybox:1.36',
         command: ['sh', '-c', `printf '%s' '${escaped}' > ${workDir}/.env`],
         resources: INIT_ENV_RESOURCES,
         volumeMounts: [{ name: 'app-data', mountPath: workDir }],
-      })
+      }))
     }
     if (podSpec.initContainers.length === 0) delete podSpec.initContainers
 
+    // 3. Create/replace the app-secrets Secret when we have a live target.
+    //    Without envId/ns we can only commit the manifest; the secretKeyRef will
+    //    resolve once the Secret exists, so we surface a clear warning.
+    let secretWarning = null
+    if (sensitiveEnv.length > 0) {
+      if (envId && ns) {
+        await createKubernetesSecret(req, {
+          envId,
+          ns,
+          name: secretForApp,
+          data: Object.fromEntries(sensitiveEnv.map((v) => [v.key, String(v.value ?? '')])),
+        })
+      } else {
+        secretWarning =
+          'Sensitive variables were referenced as secrets in the manifest but the Secret ' +
+          'could not be created (no environment/namespace context). Create it manually or ' +
+          're-save from the app detail view.'
+      }
+    }
+
     const updatedYaml = serializeManifests(docs)
 
-    const safeApp = sanitizeStackName(deployment.metadata?.name || 'app')
     await commitFiles(conn.payload, branch, `vibe: update environment variables for ${safeApp}`, [
       { path: gitPath, content: updatedYaml },
     ])
 
-    return json(res, 200, { ok: true })
+    return json(res, 200, { ok: true, ...(secretWarning ? { warning: secretWarning } : {}) })
   } catch (err) {
     console.error('[vibe update-env error]', err.message || err)
     return json(res, 500, { error: err.message || 'Update failed' })

--- a/server/routes/vibe.js
+++ b/server/routes/vibe.js
@@ -8,6 +8,7 @@ import {
   fetchFile,
   deleteFile,
   deleteDirectory,
+  deletePaths,
 } from '../proxy/git.js'
 import { buildManifests, serializeManifests, buildManifestPath } from '../lib/manifestSerialize.js'
 import yaml from 'js-yaml'
@@ -1265,9 +1266,15 @@ async function handleVibeDeleteManifest(req, res) {
   if (!data) return json(res, 400, { error: 'Invalid request body' })
 
   const { gitTargetId, branch, appName } = data
+
+  // New form: an array of paths (files and/or directories) removed atomically
+  // in a single commit. Preferred by the delete flow to avoid a non-fast-forward
+  // race between separate file and directory commits.
+  const rawPaths = Array.isArray(data.paths) ? data.paths : null
   const gitPath = sanitizeGitPath(data.gitPath)
-  if (!gitTargetId || !branch || !gitPath) {
-    return json(res, 400, { error: 'gitTargetId, branch and gitPath are required' })
+
+  if (!gitTargetId || !branch || (!rawPaths && !gitPath)) {
+    return json(res, 400, { error: 'gitTargetId, branch and (paths or gitPath) are required' })
   }
 
   const conn = getConnectionById(gitTargetId)
@@ -1278,6 +1285,14 @@ async function handleVibeDeleteManifest(req, res) {
   }
 
   try {
+    if (rawPaths) {
+      const paths = rawPaths.map((p) => sanitizeGitPath(p)).filter(Boolean)
+      if (paths.length === 0) return json(res, 400, { error: 'No valid paths provided' })
+      await deletePaths(conn.payload, branch, paths, `remove: ${appName || paths.join(', ')}`)
+      return json(res, 200, { ok: true })
+    }
+
+    // Legacy single-path form (file or directory).
     // Paths without an extension are source directories; paths with an
     // extension (.yaml/.yml) are manifest files.
     const isDirectory = !gitPath.match(/\.[a-zA-Z0-9]+$/)


### PR DESCRIPTION
# Portainer-Run: version display, secret handling, pod security, and delete hardening

This PR delivers the first tranche of open issues, plus two changes that came out of testing. It leaves the network and ingress items parked pending Pomerium validation.

Closes #45, #33, #38, #39, #44

## Version display (#45)

The running release is now surfaced bottom-left in the sidebar as "Portainer-Run [tag]", sourced from a `PORTAINER_RUN_VERSION` build arg. Tagged releases show their version, develop pushes show "develop", PR builds show "pr-[number]", and local builds show "dev". The value flows through `/config` to the client, so nothing is hardcoded. CI (`ci.yaml`) and the release workflow pass the arg at build time.

## GitLab PAT scope guidance (#33)

The git target form now states the minimum required token scope per provider, including the GitLab `api` scope and why the narrower `read_api` plus `write_repository` combination passes GitLab's own checks but fails on deploy. This is advisory guidance rather than validation. There is no reliable cross-provider API to introspect a token's granted scopes before use, so we state the requirement rather than enforce it.

## Sensitive environment variables stored as secrets (#38)

Environment variables whose names imply a secret (password, token, api_key, secret, private_key, credentials, and the rest of the common set) are now stored in a Kubernetes Secret and referenced via secretKeyRef, instead of being written into the committed manifest. Non-sensitive variables keep the existing behavior and are written to the committed .env. This applies to both the deploy path and the env update path. Detection is name-based and errs toward caution.

Behavior note: apps that read only from a .env file will no longer see secret values in that file. Those values now arrive through the container environment via the Secret.

## Pod Security Standards (#39)

All containers, application and init, now carry a hardened security context: drop all capabilities, no privilege escalation, and the RuntimeDefault seccomp profile, plus a pod-level context and automountServiceAccountToken set to false.

Scope caveat: this targets the Kubernetes baseline profile. `runAsNonRoot` and `readOnlyRootFilesystem` are deliberately not forced, because the clone, install, and env init steps and many vibe-built images legitimately write to the filesystem and start as root. Forcing non-root would break the common case. A per-deploy non-root option is a natural follow-up once adjustable base images (#42) lands.

## Delete feedback and atomic git cleanup (#44)

The delete flow now keeps the confirmation modal open with a progress indicator until the operation completes, then returns to the applications list, rather than closing early with no feedback. Separately, git cleanup for a vibe app now removes the manifest file and the source directory in a single commit. The previous two-commit sequence raced GitHub's read-after-write ref propagation and could fail the second step with a non-fast-forward error.

## Also included

When a user has access to exactly one environment and one project space, the deployment target and project space selectors are hidden entirely and replaced with a one-line summary, so non-technical users are not asked to reason about infrastructure they cannot change.