### PR TITLE
feat(chart): add Helm chart for Portainer-Run

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: portainer-run
+description: Portainer-Run — AI-assisted deployment companion for Portainer, served as a Portainer addon.
+type: application
+
+# Chart version — SemVer 2 (three segments). Bump on any change to the chart
+# or its templates, independently of the app version below.
+version: 1.2.7
+
+# Application version — the Portainer-Run release this chart ships. Free-form,
+# so it carries the full release string. Used as the image tag when
+# image.tag is left empty.
+appVersion: "1.2.7"

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,23 @@
+Portainer-Run has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+In-cluster Service (ClusterIP):
+    {{ include "portainer-run.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    ports: 443 (https), 80 (http)
+
+{{- if not .Values.secret.ENCRYPTION_KEY }}
+
+⚠️  WARNING: secret.ENCRYPTION_KEY is empty. The container exits on startup
+    without it (minimum 32 chars). Set it and upgrade:
+
+    helm upgrade {{ .Release.Name }} <chart> \
+      --set secret.ENCRYPTION_KEY="$(openssl rand -hex 32)"
+{{- end }}
+
+{{- if and (not .Values.secret.ANTHROPIC_API_KEY) (not .Values.secret.OPENAI_API_KEY) }}
+
+ℹ️  No AI provider key set — AI triage is unavailable until you set
+    secret.ANTHROPIC_API_KEY or secret.OPENAI_API_KEY.
+{{- end }}
+
+Check status:
+    kubectl -n {{ .Release.Namespace }} rollout status deploy/{{ include "portainer-run.fullname" . }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "portainer-run.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "portainer-run.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "portainer-run.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "portainer-run.labels" -}}
+helm.sh/chart: {{ include "portainer-run.chart" . }}
+{{ include "portainer-run.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "portainer-run.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "portainer-run.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -49,3 +49,35 @@ Selector labels
 app.kubernetes.io/name: {{ include "portainer-run.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Hidden configMap defaults.
+
+These keys are baked into the templates instead of values.yaml so they stay out
+of the values list Portainer renders from the OCI chart. They are still written
+into the ConfigMap (configmap.yaml) and read by the probe logic (deployment.yaml),
+so both stay in sync. Override any of them with `--set configMap.<KEY>=...`.
+
+`hasKey` (rather than sprig `default`) is used so an explicit falsy override such
+as `--set configMap.SERVE_HTTP=0` or `HTTP_PORT=0` is honored — `default` would
+treat 0/"" as empty and silently restore the fallback.
+*/}}
+{{- define "portainer-run.portainerUrl" -}}
+{{- $c := .Values.configMap | default dict -}}
+{{- if hasKey $c "PORTAINER_URL" }}{{ $c.PORTAINER_URL }}{{ else }}https://portainer.portainer.svc.cluster.local:9443{{ end -}}
+{{- end }}
+
+{{- define "portainer-run.port" -}}
+{{- $c := .Values.configMap | default dict -}}
+{{- if hasKey $c "PORT" }}{{ $c.PORT }}{{ else }}80{{ end -}}
+{{- end }}
+
+{{- define "portainer-run.httpPort" -}}
+{{- $c := .Values.configMap | default dict -}}
+{{- if hasKey $c "HTTP_PORT" }}{{ $c.HTTP_PORT }}{{ else }}443{{ end -}}
+{{- end }}
+
+{{- define "portainer-run.serveHttp" -}}
+{{- $c := .Values.configMap | default dict -}}
+{{- if hasKey $c "SERVE_HTTP" }}{{ $c.SERVE_HTTP }}{{ else }}1{{ end -}}
+{{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     {{- include "portainer-run.labels" . | nindent 4 }}
 data:
+  # Baked-in defaults (kept out of values.yaml; see _helpers.tpl).
+  PORTAINER_URL: {{ include "portainer-run.portainerUrl" . | quote }}
+  PORT: {{ include "portainer-run.port" . | quote }}
+  HTTP_PORT: {{ include "portainer-run.httpPort" . | quote }}
+  SERVE_HTTP: {{ include "portainer-run.serveHttp" . | quote }}
   {{- range $key, $value := .Values.configMap }}
+  {{- if not (has $key (list "PORTAINER_URL" "PORT" "HTTP_PORT" "SERVE_HTTP")) }}
   {{ $key }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # Fixed name: the MCP config flow reads this ConfigMap by name through the
+  # Portainer API (server/routes/mcp.js). Do not template it.
+  name: portainer-run-config
+  labels:
+    {{- include "portainer-run.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.configMap }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -63,10 +63,10 @@ spec:
               memory: 64Mi
             limits:
               memory: 256Mi
-          {{- /* Probes follow configMap.PORT (app default 443) and the serve mode: */}}
+          {{- /* Probes follow the baked-in PORT and serve mode (see _helpers.tpl): */}}
           {{- /* SERVE_HTTP=1 → plain HTTP, otherwise HTTPS. */}}
-          {{- $probePort := .Values.configMap.PORT | default "443" }}
-          {{- $probeScheme := ternary "HTTP" "HTTPS" (eq (toString (.Values.configMap.SERVE_HTTP | default "")) "1") }}
+          {{- $probePort := include "portainer-run.port" . }}
+          {{- $probeScheme := ternary "HTTP" "HTTPS" (eq (include "portainer-run.serveHttp" .) "1") }}
           livenessProbe:
             httpGet:
               path: /config

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "portainer-run.fullname" . }}
+  labels:
+    {{- include "portainer-run.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "portainer-run.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll the pod when config/secret change so new values take effect.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "portainer-run.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: portainer-run
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: Always
+          ports:
+            - name: https
+              containerPort: 443
+              protocol: TCP
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: portainer-run-config
+          env:
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portainer-run.fullname" . }}-secret
+                  key: ENCRYPTION_KEY
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portainer-run.fullname" . }}-secret
+                  key: ANTHROPIC_API_KEY
+                  optional: true
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portainer-run.fullname" . }}-secret
+                  key: OPENAI_API_KEY
+                  optional: true
+          volumeMounts:
+            - name: cache
+              mountPath: /app/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          {{- /* Probes follow configMap.PORT (app default 443) and the serve mode: */}}
+          {{- /* SERVE_HTTP=1 → plain HTTP, otherwise HTTPS. */}}
+          {{- $probePort := .Values.configMap.PORT | default "443" }}
+          {{- $probeScheme := ternary "HTTP" "HTTPS" (eq (toString (.Values.configMap.SERVE_HTTP | default "")) "1") }}
+          livenessProbe:
+            httpGet:
+              path: /config
+              port: {{ $probePort }}
+              scheme: {{ $probeScheme }}
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /config
+              port: {{ $probePort }}
+              scheme: {{ $probeScheme }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: {{ include "portainer-run.fullname" . }}-cache

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,7 +62,6 @@ spec:
               cpu: 50m
               memory: 64Mi
             limits:
-              cpu: 500m
               memory: 256Mi
           {{- /* Probes follow configMap.PORT (app default 443) and the serve mode: */}}
           {{- /* SERVE_HTTP=1 → plain HTTP, otherwise HTTPS. */}}

--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "portainer-run.fullname" . }}-cache
+  labels:
+    {{- include "portainer-run.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "portainer-run.fullname" . }}-secret
+  labels:
+    {{- include "portainer-run.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Required. The container exits on startup if this is empty or < 32 chars.
+  ENCRYPTION_KEY: {{ .Values.secret.ENCRYPTION_KEY | quote }}
+  {{- with .Values.secret.ANTHROPIC_API_KEY }}
+  ANTHROPIC_API_KEY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secret.OPENAI_API_KEY }}
+  OPENAI_API_KEY: {{ . | quote }}
+  {{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "portainer-run.fullname" . }}
+  labels:
+    {{- include "portainer-run.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "portainer-run.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: https
+      port: 443
+      targetPort: https
+      protocol: TCP
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "portainer-run.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
   selector:
     {{- include "portainer-run.selectorLabels" . | nindent 4 }}
   ports:

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "portainer-run.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: ClusterIP
   selector:
     {{- include "portainer-run.selectorLabels" . | nindent 4 }}
   ports:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,6 +14,13 @@ image:
 # Only needed when pulling from a private/mirrored registry.
 imagePullSecrets: []
 
+# Service that exposes Portainer-Run. Supported types:
+#   NodePort     — reachable on each node's IP at an auto-assigned port (default).
+#   ClusterIP    — internal-only; use behind an Ingress or the addon gateway.
+#   LoadBalancer — external IP provisioned by your cloud provider.
+service:
+  type: NodePort
+
 # StorageClass for the persistent session-cache PVC. Empty ("") uses the
 # cluster's default StorageClass; set this if your cluster has no default
 # or you need a specific class.
@@ -37,17 +44,16 @@ configMap:
   # ── File relay gateway ───────────────────────────────────────────────────────
   # Required for staged file uploads via the run-gateway proxy.
   # When set, large vibe deploy uploads use the gateway instead of inline MCP transfer.
-  GATEWAY_URL: "https://run-gateway.portainer.ai"
+  # GATEWAY_URL: "https://run-gateway.portainer.ai"
 
   # ── AI model override ────────────────────────────────────────────────────────
   # OpenAI model to use. No effect when using Anthropic.
-  OPENAI_MODEL: "gpt-4o"
+  # OPENAI_MODEL: "gpt-4o"
 
   # ── Ports ────────────────────────────────────────────────────────────────────
-  # PORT is the port the server listens on. HTTP_PORT (default 80) serves an
-  # HTTP→HTTPS redirect; set HTTP_PORT: "0" to disable it.
+  # PORT is the port the server listens on (default 443)
   PORT: "443"
-  # HTTP_PORT: "80"
+  # PORT: "80"  # Uncomment to run plain HTTP (e.g. behind a TLS-terminating proxy)
 
   # ── Addon-gateway mode (optional) ─────────────────────────────────────────────
   # Defaults to "0" — force HTTPS. Set to "1" only when served behind the
@@ -56,12 +62,8 @@ configMap:
   # port clash). Without it we run HTTPS + an HTTP→HTTPS redirect; the gateway
   # would hit that redirect and bounce the browser to the cluster DNS name, out
   # of the Portainer base URL. The probe scheme follows this value automatically.
-  SERVE_HTTP: "0"
-
-  # ── Cache directory ──────────────────────────────────────────────────────────
-  # Override the directory used for persistent cache (default: /app/data).
-  # Must match the mountPath of the cache volume in the Deployment if changed.
-  # CACHE_DIR: "/app/data"
+  # SERVE_HTTP: "0"
+  # HTTP_PORT: "80"
 
 # ── Secret (sensitive values) ────────────────────────────────────────────────
 # Rendered into an Opaque Secret (as stringData, so use plain text — no base64).
@@ -71,7 +73,7 @@ secret:
   ENCRYPTION_KEY: ""
 
   # Anthropic (Claude). Set this or OPENAI_API_KEY to enable AI triage.
-  ANTHROPIC_API_KEY: ""
+  # ANTHROPIC_API_KEY: ""
 
   # OpenAI (GPT-4o) — set instead of ANTHROPIC_API_KEY to use OpenAI.
-  OPENAI_API_KEY: ""
+  # OPENAI_API_KEY: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,29 +14,21 @@ image:
 # Only needed when pulling from a private/mirrored registry.
 imagePullSecrets: []
 
-# Service that exposes Portainer-Run. Supported types:
-#   NodePort     — reachable on each node's IP at an auto-assigned port (default).
-#   ClusterIP    — internal-only; use behind an Ingress or the addon gateway.
-#   LoadBalancer — external IP provisioned by your cloud provider.
-service:
-  type: NodePort
-
 # StorageClass for the persistent session-cache PVC. Empty ("") uses the
 # cluster's default StorageClass; set this if your cluster has no default
 # or you need a specific class.
 storageClass: ""
 
 # ── ConfigMap (non-sensitive configuration) ──────────────────────────────────
-# Rendered verbatim into the `portainer-run-config` ConfigMap and loaded into
-# the container via envFrom. The MCP config flow reads this ConfigMap by that
-# fixed name through the Portainer API, so keep uncommented keys as env keys.
+# Rendered into the `portainer-run-config` ConfigMap and loaded into the
+# container via envFrom. The MCP config flow reads this ConfigMap by that fixed
+# name through the Portainer API, so keep any keys you add here as env keys.
+#
+# PORTAINER_URL, PORT, HTTP_PORT and SERVE_HTTP are baked into the templates
+# (chart/templates/_helpers.tpl) with in-cluster defaults, so they're kept out
+# of this list. Override any of them — or set any other env key — with
+# `--set configMap.<KEY>=...` (or an overrides file) without a template change.
 configMap:
-  # Portainer API base URL. Use the in-cluster Service DNS name when
-  # Portainer-Run runs in the same cluster as Portainer
-  # If you run Portainer-Run outside the cluster, set this to the external URL of
-  # your Portainer instance (e.g. https://portainer.example.com:9443)
-  PORTAINER_URL: "https://portainer.portainer.svc.cluster.local:9443"
-
   # ── Ingress base domain ─────────────────────────────────────────────────────
   # If set, Ingress templates default to appname.BASE_DOMAIN as the host.
   # BASE_DOMAIN: "apps.example.com"
@@ -45,25 +37,6 @@ configMap:
   # Required for staged file uploads via the run-gateway proxy.
   # When set, large vibe deploy uploads use the gateway instead of inline MCP transfer.
   # GATEWAY_URL: "https://run-gateway.portainer.ai"
-
-  # ── AI model override ────────────────────────────────────────────────────────
-  # OpenAI model to use. No effect when using Anthropic.
-  # OPENAI_MODEL: "gpt-4o"
-
-  # ── Ports ────────────────────────────────────────────────────────────────────
-  # PORT is the port the server listens on (default 443)
-  PORT: "443"
-  # PORT: "80"  # Uncomment to run plain HTTP (e.g. behind a TLS-terminating proxy)
-
-  # ── Addon-gateway mode (optional) ─────────────────────────────────────────────
-  # Defaults to "0" — force HTTPS. Set to "1" only when served behind the
-  # Portainer addon gateway, which terminates TLS and proxies plain HTTP to us:
-  # then we serve HTTP directly (set PORT: "80" and HTTP_PORT: "0" to avoid a
-  # port clash). Without it we run HTTPS + an HTTP→HTTPS redirect; the gateway
-  # would hit that redirect and bounce the browser to the cluster DNS name, out
-  # of the Portainer base URL. The probe scheme follows this value automatically.
-  # SERVE_HTTP: "0"
-  # HTTP_PORT: "80"
 
 # ── Secret (sensitive values) ────────────────────────────────────────────────
 # Rendered into an Opaque Secret (as stringData, so use plain text — no base64).

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,77 @@
+# Default values for portainer-run.
+# Everything not listed here (ClusterIP service, single replica, resources,
+# security context, probes, cache PVC) is a fixed default baked into the templates.
+
+# Container image. The default points at the portainer DockerHub repo's
+# `latest` tag; override repository/tag
+# (and imagePullSecrets) for a private or mirrored (e.g. airgapped) registry,
+# or once a release process publishes versioned tags.
+image:
+  repository: portainer/portainer-run
+  # tag defaults to the chart appVersion when empty.
+  tag: latest
+
+# Only needed when pulling from a private/mirrored registry.
+imagePullSecrets: []
+
+# StorageClass for the persistent session-cache PVC. Empty ("") uses the
+# cluster's default StorageClass; set this if your cluster has no default
+# or you need a specific class.
+storageClass: ""
+
+# ── ConfigMap (non-sensitive configuration) ──────────────────────────────────
+# Rendered verbatim into the `portainer-run-config` ConfigMap and loaded into
+# the container via envFrom. The MCP config flow reads this ConfigMap by that
+# fixed name through the Portainer API, so keep uncommented keys as env keys.
+configMap:
+  # Portainer API base URL. Use the in-cluster Service DNS name when
+  # Portainer-Run runs in the same cluster as Portainer
+  # If you run Portainer-Run outside the cluster, set this to the external URL of
+  # your Portainer instance (e.g. https://portainer.example.com:9443)
+  PORTAINER_URL: "https://portainer.portainer.svc.cluster.local:9443"
+
+  # ── Ingress base domain ─────────────────────────────────────────────────────
+  # If set, Ingress templates default to appname.BASE_DOMAIN as the host.
+  # BASE_DOMAIN: "apps.example.com"
+
+  # ── File relay gateway ───────────────────────────────────────────────────────
+  # Required for staged file uploads via the run-gateway proxy.
+  # When set, large vibe deploy uploads use the gateway instead of inline MCP transfer.
+  GATEWAY_URL: "https://run-gateway.portainer.ai"
+
+  # ── AI model override ────────────────────────────────────────────────────────
+  # OpenAI model to use. No effect when using Anthropic.
+  OPENAI_MODEL: "gpt-4o"
+
+  # ── Ports ────────────────────────────────────────────────────────────────────
+  # PORT is the port the server listens on. HTTP_PORT (default 80) serves an
+  # HTTP→HTTPS redirect; set HTTP_PORT: "0" to disable it.
+  PORT: "443"
+  # HTTP_PORT: "80"
+
+  # ── Addon-gateway mode (optional) ─────────────────────────────────────────────
+  # Defaults to "0" — force HTTPS. Set to "1" only when served behind the
+  # Portainer addon gateway, which terminates TLS and proxies plain HTTP to us:
+  # then we serve HTTP directly (set PORT: "80" and HTTP_PORT: "0" to avoid a
+  # port clash). Without it we run HTTPS + an HTTP→HTTPS redirect; the gateway
+  # would hit that redirect and bounce the browser to the cluster DNS name, out
+  # of the Portainer base URL. The probe scheme follows this value automatically.
+  SERVE_HTTP: "0"
+
+  # ── Cache directory ──────────────────────────────────────────────────────────
+  # Override the directory used for persistent cache (default: /app/data).
+  # Must match the mountPath of the cache volume in the Deployment if changed.
+  # CACHE_DIR: "/app/data"
+
+# ── Secret (sensitive values) ────────────────────────────────────────────────
+# Rendered into an Opaque Secret (as stringData, so use plain text — no base64).
+secret:
+  # Required. Encrypts stored Git target credentials at rest. Min 32 chars.
+  # Generate one with: openssl rand -hex 32
+  ENCRYPTION_KEY: ""
+
+  # Anthropic (Claude). Set this or OPENAI_API_KEY to enable AI triage.
+  ANTHROPIC_API_KEY: ""
+
+  # OpenAI (GPT-4o) — set instead of ANTHROPIC_API_KEY to use OpenAI.
+  OPENAI_API_KEY: ""


### PR DESCRIPTION
This is to introduce a Helm chart for Portainer-Run for the add-ons feature.

The `values.yaml` keeps a bare-minimum surface — image, imagePullSecrets, storageClass, the ConfigMap data list, and a secret block. Everything else (ClusterIP service, single replica, resources, probes, cache PVC) is baked into the templates as fixed defaults.

Details:
- ConfigMap uses the fixed name `portainer-run-config`; the MCP config flow reads it by that name through the Portainer API, so it is not templated.
- Secret carries the required ENCRYPTION_KEY plus optional ANTHROPIC_API_KEY / OPENAI_API_KEY (rendered only when set; wired as optional secret refs).
- Liveness/readiness probes derive their port from configMap.PORT and their scheme from SERVE_HTTP, so they stay correct across serve modes.
- SERVE_HTTP defaults to "0" (HTTPS on 443) — a bare install with only the encryption key comes up cleanly, no HTTP-probe-vs-TLS mismatch or :80 clash. SERVE_HTTP=1 + PORT=80 enables plain-HTTP addon-gateway mode.
- OPENAI_MODEL and the cache PVC storageClass are configurable