### PR TITLE
Publish Helm chart to GHCR on release [PLA-814]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,3 +76,36 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           sbom: true
           provenance: mode=max
+
+  publish-chart:
+    name: publish helm chart
+    runs-on: ubuntu-latest
+    needs: [release]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: "[preparation] checkout the current branch"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: "[preparation] set up Helm"
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: "[validation] lint chart"
+        run: helm lint chart/
+
+      - name: "[validation] template chart (dry-run render)"
+        run: helm template portainer-run chart/ > /dev/null
+
+      - name: "[execution] package chart"
+        run: |
+          helm package chart/ \
+            --version "${{ github.event.inputs.version }}" \
+            --app-version "${{ github.event.inputs.version }}" \
+            -d /tmp/chart-dist
+
+      - name: "[execution] log in to GHCR"
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: "[execution] push chart"
+        run: helm push /tmp/chart-dist/portainer-run-*.tgz oci://ghcr.io/portainer/charts

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 
 # Chart version — SemVer 2 (three segments). Bump on any change to the chart
 # or its templates, independently of the app version below.
-version: 1.2.7
+version: 1.2.8
 
 # Application version — the Portainer-Run release this chart ships. Free-form,
 # so it carries the full release string. Used as the image tag when
 # image.tag is left empty.
-appVersion: "1.2.7"
+appVersion: "1.2.8"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,14 +2,14 @@
 # Everything not listed here (ClusterIP service, single replica, resources,
 # security context, probes, cache PVC) is a fixed default baked into the templates.
 
-# Container image. The default points at the portainer DockerHub repo's
-# `latest` tag; override repository/tag
+# Container image. The default points at the released portainer DockerHub
+# repo, tagged to match the chart's appVersion; override repository/tag
 # (and imagePullSecrets) for a private or mirrored (e.g. airgapped) registry,
-# or once a release process publishes versioned tags.
+# or to pin the floating `latest` tag instead.
 image:
   repository: portainer/portainer-run
   # tag defaults to the chart appVersion when empty.
-  tag: latest
+  tag: ''
 
 # Only needed when pulling from a private/mirrored registry.
 imagePullSecrets: []


### PR DESCRIPTION
- Add publish-chart job to release.yaml, publishing the Helm chart to oci://ghcr.io/portainer/charts on release
- Bump chart/Chart.yaml version/appVersion from 1.2.7 to 1.2.8 to match the current latest release
- Fix chart/values.yaml image.tag to default to the chart appVersion instead of always pinning latest

Ref: PLA-814