### PR TITLE
fix(server): forward session JWTs to Portainer as Bearer, not cookie

### DIFF
--- a/server/lib/identity.js
+++ b/server/lib/identity.js
@@ -6,18 +6,23 @@ import { resolvePortainerTarget } from '../resolve-portainer.js'
 /**
  * Build the auth header for an outbound request to Portainer, matching the
  * token type — mirroring Portainer's own bouncer. API access tokens (the "ptr_"
- * prefix) authenticate via X-API-Key; session JWTs via the portainer_api_key
- * cookie. Only the matching header is sent, never both: Portainer's apiKeyLookup
- * runs first and 401s when X-API-Key holds a non-API-key value (e.g. a JWT)
- * instead of falling through to the cookie lookup. Routing by type lets the MCP
- * server be driven by a long-lived X-API-Key while the browser keeps its JWT.
+ * prefix) authenticate via X-API-Key; session JWTs via Authorization: Bearer.
+ * Only the matching header is sent, never both: Portainer's apiKeyLookup runs
+ * first and 401s when X-API-Key holds a non-API-key value (e.g. a JWT) instead
+ * of falling through to the JWT lookup. Routing by type lets the MCP server be
+ * driven by a long-lived X-API-Key while the browser keeps its JWT.
+ *
+ * The JWT must NOT be forwarded as the portainer_api_key cookie: Portainer's
+ * CSRF middleware fails closed on unsafe cookie-authenticated requests that
+ * lack Origin/Sec-Fetch-Site headers (which server-to-server requests never
+ * carry), while token-authenticated requests are exempt.
  * @param {string} token
  * @returns {Record<string, string>}
  */
 export function portainerAuthHeaders(token) {
   return token.startsWith('ptr_')
     ? { 'X-API-Key': token }
-    : { 'Cookie': `portainer_api_key=${token}` }
+    : { 'Authorization': `Bearer ${token}` }
 }
 
 /**


### PR DESCRIPTION
Portainer's CSRF middleware fails closed on cookie-authenticated writes without Origin/Sec-Fetch-Site headers, so the addon's server-side deploy calls (secret creation) 403'd in addon-gateway mode. Session JWTs are now forwarded as `Authorization: Bearer`, which Portainer accepts and exempts from the CSRF check; `ptr_` API keys still go via X-API-Key.

## Verification
- Deploy an app via the addon UI (vibe Deploy) with sensitive env vars on an in-cluster Portainer; the app-secrets Secret is created and the deploy succeeds without a CSRF 403 in Portainer logs.
- Deploy with a git-backed source; the git-credentials Secret and GitOps stack are created.
- Drive the MCP endpoint with a `ptr_` API access token; requests still authenticate.
- Confirm `CSRF_ALLOW_NO_ORIGIN` is NOT set on the Portainer deployment while testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)