### PR TITLE
feat(addons): use shortDescription in app switcher [R8S-1180]

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -95,7 +95,7 @@ function useShellBreadcrumbs(): BreadcrumbItem[] {
 export function AppLayout() {
   const selectedProduct = {
     id: 'portainer-run',
-    label: 'Portainer Run',
+    label: 'Portainer-Run',
     logo: (
       <img src="/assets/addons/portainer-run.png" alt="portainer run logo" />
     ),

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -99,7 +99,7 @@ export function AppLayout() {
     logo: (
       <img src="/assets/addons/portainer-run.png" alt="portainer run logo" />
     ),
-    description: 'Deploy and manage applications.',
+    description: "Drag'n'drop deployment for Apps",
     color: '#8b5cf6',
     available: true,
     path: '/',

--- a/client/src/lib/addonToProduct.tsx
+++ b/client/src/lib/addonToProduct.tsx
@@ -4,7 +4,9 @@ export function addonToProduct(addon: AddonsAddonListItem) {
   return {
     id: addon.id!,
     label: addon.displayName!,
-    description: addon.description!,
+    // The app switcher is space-constrained, so prefer the short tagline;
+    // fall back to the full description until the catalog serves shortDescription.
+    description: addon.shortDescription ?? addon.description!,
     available: true,
     color: '#8b5cf6',
     logo: <img src={addon.icon} alt={addon.displayName} />,

--- a/client/src/lib/getAddons.ts
+++ b/client/src/lib/getAddons.ts
@@ -3,6 +3,7 @@ import { apiFetch } from '@/lib/api'
 
 export type AddonsAddonListItem = {
   description?: string
+  shortDescription?: string
   displayName?: string
   healthMessage?: string
   healthStatus?: AddonHealthStatus


### PR DESCRIPTION
The app switcher is space-constrained, so show the catalogs one-line shortDescription tagline instead of the full description. Falls back to description until the catalog serves shortDescription.

- getAddons: carry shortDescription on AddonsAddonListItem
- addonToProduct: prefer shortDescription ?? description
- AppLayout: set Portainer Runs own tagline to "Dragndrop deployment for Apps"