### PR TITLE
fix(chart): base64-encode secret values so cleared keys are pruned [R8S-1188]

### DIFF
--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -5,12 +5,12 @@ metadata:
   labels:
     {{- include "portainer-run.labels" . | nindent 4 }}
 type: Opaque
-stringData:
+data:
   # Required. The container exits on startup if this is empty or < 32 chars.
-  ENCRYPTION_KEY: {{ .Values.secret.ENCRYPTION_KEY | quote }}
+  ENCRYPTION_KEY: {{ .Values.secret.ENCRYPTION_KEY | b64enc | quote }}
   {{- with .Values.secret.ANTHROPIC_API_KEY }}
-  ANTHROPIC_API_KEY: {{ . | quote }}
+  ANTHROPIC_API_KEY: {{ . | b64enc | quote }}
   {{- end }}
   {{- with .Values.secret.OPENAI_API_KEY }}
-  OPENAI_API_KEY: {{ . | quote }}
+  OPENAI_API_KEY: {{ . | b64enc | quote }}
   {{- end }}


### PR DESCRIPTION
The Secret wrote keys via stringData, which the API server converts to data on write. Under server-side apply the field manager only owns the virtual stringData.* path, so clearing an optional key (e.g. an AI API key) pruned the stringData entry but orphaned the persisted data.* one — the old value stayed in the Secret and the pod kept reading it.

Write the keys under data with b64enc instead. Ownership now tracks the real data.* field, so a key removed by its {{- with }} guard is pruned on apply. Values passed to the chart stay plain text; b64enc encodes them at render time