### PR TITLE
fix(ui): deploy upload picker, nav cmd+click links, app breadcrumbs

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { forwardRef, useEffect, useMemo, useState } from 'react'
+import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { Box, Home, MessageSquare, type LucideIcon } from 'lucide-react'
 
 import { AppShell } from '@ds/v3-templates/AppShell/AppShell'
@@ -75,19 +75,37 @@ function appFromPath(pathname: string): Favorite | null {
   }
 }
 
+/**
+ * Link element the design-system shell (sidebar nav items + breadcrumbs)
+ * renders through its `as` prop. Passing a real anchor / router `Link` — rather
+ * than an `onClick` handler — is what gives these controls native
+ * cmd/ctrl/middle-click "open in new tab" behavior.
+ *
+ * Two modes, chosen per-item via `linkProps`:
+ *  - `{ to }`   → in-SPA navigation via react-router's `Link`.
+ *  - `{ href }` → a plain `<a>` for links that must bypass the SPA router
+ *                 (e.g. the "Portainer" item that returns to the host app root).
+ */
+const ShellLink = forwardRef<
+  HTMLAnchorElement,
+  { to?: string; href?: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>
+>(function ShellLink({ to, href, ...rest }, ref) {
+  if (href != null) return <a ref={ref} href={href} {...rest} />
+  return <Link ref={ref} to={to ?? '#'} {...rest} />
+})
+
 function useShellBreadcrumbs(): BreadcrumbItem[] {
   const { pathname } = useLocation()
-  const navigate = useNavigate()
   const items = getBreadcrumbItems(pathname)
   return [
     {
       label: '',
       icon: <Home size={14} />,
-      onClick: () => navigate(ROUTES.dashboard),
+      linkProps: { to: ROUTES.dashboard },
     },
     ...items.map((item: { label: string; to?: string; current?: boolean }) => ({
       label: item.label,
-      onClick: item.to ? () => navigate(item.to as string) : undefined,
+      linkProps: item.to ? { to: item.to } : undefined,
     })),
   ]
 }
@@ -214,7 +232,14 @@ export function AppLayout() {
         id: item.id,
         label: item.label,
         icon: item.icon,
-        href: item.href,
+        // Internal routes navigate in-SPA (`to`); the external "Portainer"
+        // item bypasses the router with a plain `href`. Either way the shell
+        // renders a real link, so cmd/ctrl/middle-click opens a new tab.
+        linkProps: item.path
+          ? { to: item.path }
+          : item.href
+            ? { href: item.href }
+            : undefined,
       })),
     }))
 
@@ -228,12 +253,13 @@ export function AppLayout() {
         id: `fav:${favoriteKey(f)}`,
         label: f.name,
         icon: AppFavTag,
-        onClick: () =>
-          navigate(serviceDetailRootPath(f.envId, f.namespace, f.name)),
+        linkProps: {
+          to: serviceDetailRootPath(f.envId, f.namespace, f.name),
+        },
       })),
     }
     return [favoritesSection, ...navShellSections]
-  }, [sections, favorites, navigate])
+  }, [sections, favorites])
 
   const activeId =
     sections
@@ -241,11 +267,6 @@ export function AppLayout() {
       .find((item) => item.path && pathname.startsWith(item.path))?.id ?? ''
 
   const breadcrumbs = useShellBreadcrumbs()
-
-  function handleNavClick(id: string) {
-    const item = sections.flatMap((s) => s.items).find((i) => i.id === id)
-    if (item?.path) navigate(item.path)
-  }
 
   function handleAddonClick(id: string) {
     const item: AddonsAddonListItem | undefined = products.find(
@@ -274,7 +295,7 @@ export function AppLayout() {
         <AppShell
           sections={shellSections}
           activeId={activeId}
-          onItemClick={handleNavClick}
+          as={ShellLink}
           logo={<SidebarLogo />}
           collapsedLogo={<SidebarLogoCollapsed />}
           productSlot={(collapsed) => (

--- a/client/src/lib/breadcrumbs.js
+++ b/client/src/lib/breadcrumbs.js
@@ -31,7 +31,7 @@ export function getBreadcrumbItems(pathname) {
   }
 
   const serviceMatch = matchPath(
-    { path: '/services/:envId/:namespace/:name/:tab', end: true },
+    { path: '/applications/:envId/:namespace/:name/:tab?', end: true },
     path,
   )
   if (serviceMatch) {

--- a/client/src/pages/deploy/DeployStepUi.tsx
+++ b/client/src/pages/deploy/DeployStepUi.tsx
@@ -33,39 +33,13 @@ export function DropZone({
   const accent = 'var(--accent, #2e90fa)'
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onDragOver={(e) => {
-        e.preventDefault()
-        setDragging(true)
-      }}
-      onDragLeave={() => setDragging(false)}
-      onDrop={onDrop}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      onClick={() => folderRef.current?.click()}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          folderRef.current?.click()
-        }
-      }}
-      style={{
-        border: `1.5px dashed ${active ? accent : 'var(--border)'}`,
-        borderRadius: 12,
-        padding: '40px 24px',
-        textAlign: 'center',
-        cursor: 'pointer',
-        outline: 'none',
-        background: dragging
-          ? `color-mix(in srgb, ${accent} 8%, transparent)`
-          : hover
-            ? 'color-mix(in srgb, var(--text) 3%, transparent)'
-            : 'transparent',
-        transition: 'border-color 120ms ease, background-color 120ms ease',
-      }}
-    >
+    <>
+      {/* Hidden pickers live OUTSIDE the clickable dropzone below. A
+          programmatic `input.click()` dispatches a click event that bubbles;
+          if the input were nested in the dropzone, that event would reach the
+          dropzone's onClick and re-open the folder picker — so "Upload files"
+          would wrongly show the folder picker. Keeping them as siblings avoids
+          that. */}
       <input
         ref={folderRef}
         type="file"
@@ -89,56 +63,90 @@ export function DropZone({
         }}
       />
       <div
-        style={{
-          width: 52,
-          height: 52,
-          borderRadius: '50%',
-          margin: '0 auto 16px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          background: `color-mix(in srgb, ${accent} 12%, transparent)`,
-          color: accent,
-          transition: 'transform 120ms ease',
-          transform: active ? 'translateY(-2px)' : 'none',
+        role="button"
+        tabIndex={0}
+        onDragOver={(e) => {
+          e.preventDefault()
+          setDragging(true)
         }}
-      >
-        <Upload size={22} />
-      </div>
-      <div
-        style={{
-          fontSize: 15,
-          fontWeight: 600,
-          color: 'var(--text)',
-          marginBottom: 4,
-        }}
-      >
-        {dragging ? 'Drop to upload' : 'Drop your project folder here'}
-      </div>
-      <div style={{ fontSize: 13, color: 'var(--muted)', marginBottom: 18 }}>
-        or browse below — we&rsquo;ll detect the runtime automatically
-      </div>
-      <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
-        <Button
-          variant="ghost"
-          onClick={(e) => {
-            e.stopPropagation()
+        onDragLeave={() => setDragging(false)}
+        onDrop={onDrop}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+        onClick={() => folderRef.current?.click()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
             folderRef.current?.click()
+          }
+        }}
+        style={{
+          border: `1.5px dashed ${active ? accent : 'var(--border)'}`,
+          borderRadius: 12,
+          padding: '40px 24px',
+          textAlign: 'center',
+          cursor: 'pointer',
+          outline: 'none',
+          background: dragging
+            ? `color-mix(in srgb, ${accent} 8%, transparent)`
+            : hover
+              ? 'color-mix(in srgb, var(--text) 3%, transparent)'
+              : 'transparent',
+          transition: 'border-color 120ms ease, background-color 120ms ease',
+        }}
+      >
+        <div
+          style={{
+            width: 52,
+            height: 52,
+            borderRadius: '50%',
+            margin: '0 auto 16px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: `color-mix(in srgb, ${accent} 12%, transparent)`,
+            color: accent,
+            transition: 'transform 120ms ease',
+            transform: active ? 'translateY(-2px)' : 'none',
           }}
         >
-          Upload folder
-        </Button>
-        <Button
-          variant="ghost"
-          onClick={(e) => {
-            e.stopPropagation()
-            filesRef.current?.click()
+          <Upload size={22} />
+        </div>
+        <div
+          style={{
+            fontSize: 15,
+            fontWeight: 600,
+            color: 'var(--text)',
+            marginBottom: 4,
           }}
         >
-          Upload files
-        </Button>
+          {dragging ? 'Drop to upload' : 'Drop your project folder here'}
+        </div>
+        <div style={{ fontSize: 13, color: 'var(--muted)', marginBottom: 18 }}>
+          or browse below — we&rsquo;ll detect the runtime automatically
+        </div>
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+          <Button
+            variant="ghost"
+            onClick={(e) => {
+              e.stopPropagation()
+              folderRef.current?.click()
+            }}
+          >
+            Upload folder
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={(e) => {
+              e.stopPropagation()
+              filesRef.current?.click()
+            }}
+          >
+            Upload files
+          </Button>
+        </div>
       </div>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
Closes R8S-1202

## Summary

A few UI fixes for the deploy wizard and app-shell navigation, plus a design-system submodule bump.

## Changes

- **Deploy wizard — "Upload files" button opened the folder picker.** The hidden file `<input>`s were children of the clickable dropzone, so the button's programmatic `.click()` bubbled up to the dropzone's `onClick`, which re-opened the folder (`webkitdirectory`) picker. Moved both inputs out into a wrapping fragment so their clicks no longer re-trigger the dropzone. "Upload files" now opens a file picker; "Upload folder" opens a folder picker.

- **Sidebar & breadcrumbs now support cmd/ctrl/middle-click "open in new tab".** Wired `AppShell`'s `as` prop to a small router-`Link` adapter and switched nav items, favorites, and breadcrumbs from `onClick` handlers to `linkProps`. They render as real anchors now. Internal routes use `{ to }` (react-router `Link`); the external "Portainer" item uses `{ href }` so it still does a full navigation to the host root, bypassing the SPA router.

- **App detail breadcrumbs showed "App" instead of "Applications › &lt;name&gt;".** The breadcrumb matcher still used the old `/services` prefix and required a `:tab` segment. Updated to `/applications/:envId/:namespace/:name/:tab?` so the overview page, the tab-less index redirect, and deeper tabs all resolve correctly.

- **Bumped the `design-system` submodule to latest (`7057eba`).** Brings in the `AppShell`/`Sidebar`/`PageHeader` `as`-prop forwarding used by the cmd+click change, the `ApplicationSwitcher` `logoHref`/`onLogoClick` props (resolves a pre-existing type error in `AppLayout`), and assorted visual/token fixes.

## Testing

- `tsc --noEmit` and `eslint` clean (also enforced by the pre-commit hook on each commit).
- Verified breadcrumb output for `/applications/:env/:ns/:name`, its overview/tabbed variants, and the tab-less redirect path.
- Verified the dropzone renders the two file inputs correctly and that "Upload files" no longer re-triggers the folder picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)