### PR TITLE
feat(deploy): expose apps via ingress URL only

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "version": "0.0.0",
   "scripts": {
-    "dev": "bun --bun vite",
+    "dev": "bun --watch --bun vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/client/src/pages/deploy/DeployPage.tsx
+++ b/client/src/pages/deploy/DeployPage.tsx
@@ -161,7 +161,7 @@ export function VibeDeploy() {
   const [manualNsValue, setManualNsValue] = useState('')
   const [nsHint, setNsHint] = useState({ text: '', tone: 'dim' })
   const instances = 1
-  const [exposeType, setExposeType] = useState('NodePort')
+  const [exposeType, setExposeType] = useState('Ingress')
   const [svcPort] = useState('')
   const [ingHost, setIngHost] = useState('')
   const [ingPath] = useState('/')
@@ -359,13 +359,8 @@ export function VibeDeploy() {
           defaultIngressClass: defaultClass,
         }
         setEnvCapabilities(caps)
-        // Auto-set expose type: prefer Ingress when it is available on the cluster
-        setExposeType((prev) => {
-          if (prev === 'LoadBalancer' && !caps.lbOk) return 'NodePort'
-          if (prev === 'Ingress' && !caps.ingressOk) return 'NodePort'
-          if (caps.ingressOk) return 'Ingress'
-          return prev
-        })
+        // Exposure is always via a URL through the cluster ingress controller.
+        setExposeType('Ingress')
         // Auto-populate ingress class from cluster default
         if (defaultClass) setIngClass(defaultClass)
       })
@@ -857,7 +852,7 @@ export function VibeDeploy() {
     setAppName('')
     setEnvId('')
     setNamespace('')
-    setExposeType('NodePort')
+    setExposeType('Ingress')
     setIngHost('')
     setIngClass('')
     goTo('files')
@@ -1098,8 +1093,6 @@ export function VibeDeploy() {
                   nsStatusColor={nsStatusColor}
                   resolvedNs={resolvedNs}
                   perms={perms}
-                  exposeType={exposeType}
-                  setExposeType={setExposeType}
                   envCapabilities={envCapabilities}
                   ingHost={ingHost}
                   setIngHost={setIngHost}

--- a/client/src/pages/deploy/DetailsStep.tsx
+++ b/client/src/pages/deploy/DetailsStep.tsx
@@ -56,8 +56,6 @@ interface DetailsStepProps {
   nsStatusColor: string
   resolvedNs: string
   perms: DeployPerms | null
-  exposeType: string
-  setExposeType: Dispatch<SetStateAction<string>>
   envCapabilities: EnvCapabilities
   ingHost: string
   setIngHost: Dispatch<SetStateAction<string>>
@@ -87,8 +85,6 @@ export function DetailsStep({
   nsStatusColor,
   resolvedNs,
   perms,
-  exposeType,
-  setExposeType,
   envCapabilities,
   ingHost,
   setIngHost,
@@ -243,140 +239,81 @@ export function DetailsStep({
           />
         )}
 
-        <div style={{ maxWidth: 420 }}>
-          <FormControl label="Expose as">
-            <div>
-              <Select
-                value={exposeType}
-                onChange={(e) => setExposeType(e.target.value)}
-                disabled={envCapabilities.probing}
-                options={[
-                  {
-                    value: 'NodePort',
-                    label:
-                      'Network Accessible - Default, use this unless advised otherwise',
-                  },
-                  ...(envCapabilities.probing || envCapabilities.lbOk !== false
-                    ? [
-                        {
-                          value: 'LoadBalancer',
-                          label: 'Network Accessible via dedicated IP',
-                        },
-                      ]
-                    : []),
-                  ...(envCapabilities.probing ||
-                  envCapabilities.ingressOk !== false
-                    ? [
-                        {
-                          value: 'Ingress',
-                          label: 'Network Accessible via a URL',
-                        },
-                      ]
-                    : []),
-                ]}
-              />
-              {!envCapabilities.probing &&
-                envId &&
-                (envCapabilities.lbOk === false ||
-                  envCapabilities.ingressOk === false) && (
-                  <div style={{ ...HINT_STYLE, marginTop: 4 }}>
-                    {[
-                      envCapabilities.lbOk === false && 'LoadBalancer',
-                      envCapabilities.ingressOk === false && 'Ingress',
-                    ]
-                      .filter(Boolean)
-                      .join(' and ')}{' '}
-                    not detected on this cluster — option
-                    {envCapabilities.lbOk === false &&
-                    envCapabilities.ingressOk === false
-                      ? 's'
-                      : ''}{' '}
-                    hidden
-                  </div>
-                )}
-            </div>
-          </FormControl>
-        </div>
-
-        {exposeType === 'Ingress' && (
-          <div style={{ display: 'flex', gap: 12 }}>
-            <div style={{ flex: 1 }}>
-              <FormControl label="Hostname">
-                {activeBaseDomain ? (
-                  <div
-                    style={{ display: 'flex', alignItems: 'center', gap: 0 }}
-                  >
-                    <Input
-                      type="text"
-                      value={appName}
-                      onChange={(e) =>
-                        setAppName(
-                          e.target.value
-                            .replace(/[^a-z0-9-]/gi, '-')
-                            .toLowerCase(),
-                        )
-                      }
-                      style={{
-                        borderRadius: '6px 0 0 6px',
-                        borderRight: 'none',
-                        flex: '0 0 auto',
-                        width: 140,
-                      }}
-                    />
-                    <span
-                      style={{
-                        padding: '8px 12px',
-                        background: 'var(--bg)',
-                        border: '1px solid var(--border)',
-                        borderRadius: '0 6px 6px 0',
-                        fontFamily: MONO_FONT,
-                        fontSize: 13,
-                        color: 'var(--muted)',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      .{activeBaseDomain}
-                    </span>
-                  </div>
-                ) : (
+        <div style={{ display: 'flex', gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <FormControl label="Hostname">
+              {activeBaseDomain ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 0 }}>
                   <Input
                     type="text"
-                    value={ingHost}
-                    onChange={(e) => setIngHost(e.target.value)}
-                    placeholder="app.example.com"
-                  />
-                )}
-              </FormControl>
-            </div>
-            <div style={{ flex: 1 }}>
-              <FormControl label="Ingress class">
-                {envCapabilities.ingressClasses.length > 1 ? (
-                  <Select
-                    value={ingClass}
-                    onChange={(e) => setIngClass(e.target.value)}
-                    options={envCapabilities.ingressClasses.map((c) => ({
-                      value: c.name,
-                      label: `${c.name}${c.isDefault ? ' (default)' : ''}`,
-                    }))}
-                  />
-                ) : (
-                  <Input
-                    type="text"
-                    value={ingClass}
-                    onChange={(e) => setIngClass(e.target.value)}
-                    placeholder="nginx"
-                    readOnly={envCapabilities.ingressClasses.length === 1}
-                    style={
-                      envCapabilities.ingressClasses.length === 1
-                        ? { opacity: 0.6, cursor: 'default' }
-                        : {}
+                    value={appName}
+                    onChange={(e) =>
+                      setAppName(
+                        e.target.value
+                          .replace(/[^a-z0-9-]/gi, '-')
+                          .toLowerCase(),
+                      )
                     }
+                    style={{
+                      borderRadius: '6px 0 0 6px',
+                      borderRight: 'none',
+                      flex: '0 0 auto',
+                      width: 140,
+                    }}
                   />
-                )}
-              </FormControl>
-            </div>
+                  <span
+                    style={{
+                      padding: '8px 12px',
+                      background: 'var(--bg)',
+                      border: '1px solid var(--border)',
+                      borderRadius: '0 6px 6px 0',
+                      fontFamily: MONO_FONT,
+                      fontSize: 13,
+                      color: 'var(--muted)',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    .{activeBaseDomain}
+                  </span>
+                </div>
+              ) : (
+                <Input
+                  type="text"
+                  value={ingHost}
+                  onChange={(e) => setIngHost(e.target.value)}
+                  placeholder="app.example.com"
+                />
+              )}
+            </FormControl>
           </div>
-        )}
+          <div style={{ flex: 1 }}>
+            <FormControl label="Ingress class">
+              {envCapabilities.ingressClasses.length > 1 ? (
+                <Select
+                  value={ingClass}
+                  onChange={(e) => setIngClass(e.target.value)}
+                  options={envCapabilities.ingressClasses.map((c) => ({
+                    value: c.name,
+                    label: `${c.name}${c.isDefault ? ' (default)' : ''}`,
+                  }))}
+                />
+              ) : (
+                <Input
+                  type="text"
+                  value={ingClass}
+                  onChange={(e) => setIngClass(e.target.value)}
+                  placeholder="nginx"
+                  readOnly={envCapabilities.ingressClasses.length === 1}
+                  style={
+                    envCapabilities.ingressClasses.length === 1
+                      ? { opacity: 0.6, cursor: 'default' }
+                      : {}
+                  }
+                />
+              )}
+            </FormControl>
+          </div>
+        </div>
 
         {(!appName || !envId || !resolvedNs) && (
           <div

--- a/client/src/pages/service-detail/VibeEditTab.tsx
+++ b/client/src/pages/service-detail/VibeEditTab.tsx
@@ -2,12 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { FileText, Upload, X } from 'lucide-react'
 
 import { Button } from '@ds/v3-components/Button/Button'
-import {
-  FormControl,
-  Input,
-  NumberInput,
-} from '@ds/v3-components/FormField/FormField'
-import { Select } from '@ds/v3-components/Select/Select'
+import { FormControl, Input } from '@ds/v3-components/FormField/FormField'
 
 import { useAppStore } from '../../store/useAppStore.js'
 import { serverFetch } from '../../lib/api.js'
@@ -64,8 +59,9 @@ export function VibeEditTab({
   const folderRef = useRef<HTMLInputElement>(null)
   const filesRef = useRef<HTMLInputElement>(null)
 
-  // Exposure state — populated from git manifest on mount
-  const [exposeType, setExposeType] = useState('NodePort')
+  // Exposure state — populated from git manifest on mount.
+  // Exposure is always via a URL through the cluster ingress controller.
+  const exposeType = 'Ingress'
   const [svcPort, setSvcPort] = useState(80)
   const [ingHost, setIngHost] = useState('')
   const [ingPath, setIngPath] = useState('/')
@@ -100,7 +96,6 @@ export function VibeEditTab({
           } | null,
         ) => {
           if (!data) return
-          if (data.exposeType) setExposeType(data.exposeType)
           if (data.port) setSvcPort(data.port)
           if (data.ingHost) setIngHost(data.ingHost)
           if (data.ingPath) setIngPath(data.ingPath)
@@ -346,64 +341,24 @@ export function VibeEditTab({
       {/* Exposure */}
       <Section title="Exposure">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <FormControl label="Expose service as">
-            <Select
-              value={exposeType}
-              onChange={(e) => setExposeType(e.target.value)}
-              options={[
-                {
-                  value: 'NodePort',
-                  label:
-                    'Network Accessible - Default, use this unless advised otherwise',
-                },
-                {
-                  value: 'LoadBalancer',
-                  label: 'Network Accessible via dedicated IP',
-                },
-                { value: 'Ingress', label: 'Network Accessible via a URL' },
-              ]}
-            />
-          </FormControl>
-          {(exposeType === 'NodePort' || exposeType === 'LoadBalancer') && (
-            <FormControl label="Port">
-              <div style={{ width: 120 }}>
-                <NumberInput
-                  value={svcPort}
-                  onChange={(v) => setSvcPort(Number(v))}
-                />
-              </div>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <FormControl label="Hostname" style={{ flex: 1 }}>
+              <Input
+                type="text"
+                value={ingHost}
+                onChange={(e) => setIngHost(e.target.value)}
+                placeholder="app.example.com"
+              />
             </FormControl>
-          )}
-          {exposeType === 'Ingress' && (
-            <>
-              <FormControl label="Hostname">
-                <Input
-                  type="text"
-                  value={ingHost}
-                  onChange={(e) => setIngHost(e.target.value)}
-                  placeholder="app.example.com"
-                />
-              </FormControl>
-              <div style={{ display: 'flex', gap: 12 }}>
-                <FormControl label="Path" style={{ flex: 1 }}>
-                  <Input
-                    type="text"
-                    value={ingPath}
-                    onChange={(e) => setIngPath(e.target.value)}
-                    placeholder="/"
-                  />
-                </FormControl>
-                <FormControl label="Ingress class" style={{ flex: 1 }}>
-                  <Input
-                    type="text"
-                    value={ingClass}
-                    onChange={(e) => setIngClass(e.target.value)}
-                    placeholder="nginx"
-                  />
-                </FormControl>
-              </div>
-            </>
-          )}
+            <FormControl label="Ingress class" style={{ flex: 1 }}>
+              <Input
+                type="text"
+                value={ingClass}
+                onChange={(e) => setIngClass(e.target.value)}
+                placeholder="nginx"
+              />
+            </FormControl>
+          </div>
           {exposureError && <div style={ERROR_TEXT}>{exposureError}</div>}
           <div>
             <Button

--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -54,7 +54,7 @@ const SERVER_INSTRUCTIONS = [
   '2. Namespace — call list_namespaces. If more than one is returned, ask which to use.',
   '3. Git target — call list_git_targets. If none exist, tell the user to create one in the Portainer-Run UI (git targets cannot be created via MCP) and stop. If several exist, ask which.',
   '4. App name — propose one and confirm it with the user.',
-  '5. Exposure — decide how the app should be reachable: none, NodePort, LoadBalancer, or Ingress. Call list_ingress_classes first to inform the choice: if it reports a baseDomain (ingressHostRequired is false), PREFER Ingress so the app gets a real URL — do NOT use NodePort when a base domain is available unless the user explicitly asks for NodePort. If there is no base domain, NodePort is the usual default. When in doubt, ask the user.',
+  '5. Exposure — apps are always exposed at a URL through the cluster ingress controller. Call list_ingress_classes to inform the ingress settings: it reports a baseDomain (when ingressHostRequired is false the host is derived) and the available ingress classes.',
   '6. Ingress (when chosen) — from list_ingress_classes, if ingressHostRequired is true ask the user for the full hostname (otherwise the host is derived as <appName>.<baseDomain>). Confirm which ingress class to use, or let it default to the cluster default.',
   '7. Environment variables / secrets — if the app needs any, list them and ask the user for values.',
   '',
@@ -64,7 +64,7 @@ const SERVER_INSTRUCTIONS = [
   '',
   'Always show a summary of the chosen settings and get explicit confirmation before calling deploy_app.',
   '',
-  'After deploying, report the access URL to the user. The deploy result has a "url" field; if it is null (NodePort/LoadBalancer addresses are assigned asynchronously), call get_app_status after a short wait to retrieve the URL.',
+  'After deploying, report the access URL to the user. The deploy result has a "url" field; if it is null, call get_app_status after a short wait to retrieve the URL.',
 ].join('\n')
 
 // ---------------------------------------------------------------------------
@@ -108,7 +108,7 @@ function buildTools() {
     name: 'list_ingress_classes',
     description:
       'List the IngressClasses defined in a Kubernetes environment, including which one is the cluster default. ' +
-      'Call this when deploying with exposeType "Ingress" to choose the correct ingress class. If you omit ' +
+      'Call this when deploying to choose the correct ingress class. If you omit ' +
       'ingressClass on deploy_app, the cluster default (if any) is applied automatically. ' +
       'The response also reports baseDomain and ingressHostRequired: when ingressHostRequired is true there is ' +
       'no base domain to derive a hostname from, so you must supply a full ingress.host — ask the user for it.',
@@ -197,21 +197,15 @@ function buildTools() {
             },
           },
         },
-        exposeType: {
-          type: 'string',
-          enum: ['none', 'NodePort', 'LoadBalancer', 'Ingress'],
-          description:
-            'How to expose the app externally. Default: Ingress when the server has a base domain configured (a hostname can be derived), otherwise NodePort.',
-        },
         ingress: {
           type: 'object',
           description:
-            'Ingress settings, used only when exposeType is "Ingress". If host is omitted and a base domain is configured, defaults to <appName>.<baseDomain>.',
+            'Ingress settings. The app is always exposed at a URL through the cluster ingress controller. If host is omitted and a base domain is configured, defaults to <appName>.<baseDomain>.',
           properties: {
             host: {
               type: 'string',
               description:
-                'Full ingress hostname, e.g. my-app.example.com. Required when exposeType is "Ingress" unless the server has a base domain configured (check list_ingress_classes — ingressHostRequired). If no base domain is configured, ask the user for the hostname.',
+                'Full ingress hostname, e.g. my-app.example.com. Required unless the server has a base domain configured (check list_ingress_classes — ingressHostRequired). If no base domain is configured, ask the user for the hostname.',
             },
             path: { type: 'string', description: 'Ingress path. Default: /' },
             ingressClass: {
@@ -698,31 +692,23 @@ async function toolDeployVibeApp(req, args, caller) {
     )
   }
 
-  // Default exposure: when a base domain is configured we can derive a real
-  // hostname, so default to Ingress; otherwise fall back to NodePort.
-  const exposeType = args.exposeType || (BASE_DOMAIN ? 'Ingress' : 'NodePort')
+  // Apps are always exposed at a URL through the cluster ingress controller.
+  const exposeType = 'Ingress'
 
   const safeAppName = appName.toLowerCase().replace(/[^a-z0-9-]/g, '-')
 
-  // Resolve ingress settings. When exposing via Ingress without an explicit host,
-  // fall back to <appName>.<BASE_DOMAIN> if a base domain is configured — mirroring
-  // the template/UI default. Without a host, buildVibeManifests skips the Ingress.
-  const resolvedIngress =
-    exposeType === 'Ingress'
-      ? {
-          host:
-            ingress.host ||
-            (BASE_DOMAIN ? `${safeAppName}.${BASE_DOMAIN}` : ''),
-          path: ingress.path || '/',
-          ...(ingress.ingressClass
-            ? { ingressClass: ingress.ingressClass }
-            : {}),
-        }
-      : {}
+  // Resolve ingress settings. Without an explicit host, fall back to
+  // <appName>.<BASE_DOMAIN> if a base domain is configured — mirroring the
+  // template/UI default.
+  const resolvedIngress = {
+    host: ingress.host || (BASE_DOMAIN ? `${safeAppName}.${BASE_DOMAIN}` : ''),
+    path: ingress.path || '/',
+    ...(ingress.ingressClass ? { ingressClass: ingress.ingressClass } : {}),
+  }
 
-  if (exposeType === 'Ingress' && !resolvedIngress.host) {
+  if (!resolvedIngress.host) {
     throw new Error(
-      'exposeType "Ingress" requires ingress.host (or a configured BASE_DOMAIN)',
+      'An ingress host is required (provide ingress.host or configure BASE_DOMAIN)',
     )
   }
 
@@ -730,7 +716,7 @@ async function toolDeployVibeApp(req, args, caller) {
   // claimed by a controller: prefer the cluster default, else use the only class
   // if there is exactly one (the common single-controller, e.g. nginx, case).
   // Best effort — if the lookup fails or it's ambiguous, deploy without a class.
-  if (exposeType === 'Ingress' && !resolvedIngress.ingressClass) {
+  if (!resolvedIngress.ingressClass) {
     try {
       const target = resolvePortainerTarget()
       if (target) {
@@ -872,12 +858,10 @@ async function toolDeployVibeApp(req, args, caller) {
   }
   const deployedName = data.appName || safeAppName
 
-  // Resolve an access URL for the response. Ingress hosts are known immediately;
-  // NodePort/LoadBalancer addresses are assigned asynchronously so we poll briefly.
+  // Resolve an access URL for the response. Ingress hosts are known immediately.
   let access = null
   try {
-    const target = resolvePortainerTarget()
-    if (exposeType === 'Ingress' && resolvedIngress.host) {
+    if (resolvedIngress.host) {
       const p =
         resolvedIngress.path && resolvedIngress.path !== '/'
           ? resolvedIngress.path
@@ -887,18 +871,6 @@ async function toolDeployVibeApp(req, args, caller) {
         label: resolvedIngress.host,
         type: 'ingress',
       }
-    } else if (
-      target &&
-      (exposeType === 'NodePort' || exposeType === 'LoadBalancer')
-    ) {
-      access = await resolveAppAccessUrl(
-        target,
-        token,
-        envId,
-        namespace,
-        deployedName,
-        { attempts: 4, delayMs: 1500 },
-      )
     }
   } catch {
     /* best effort — URL is a convenience */
@@ -910,10 +882,9 @@ async function toolDeployVibeApp(req, args, caller) {
     if (access.type === 'ingress')
       message +=
         ' (ensure DNS for the host points to your ingress controller; served over HTTP unless TLS is configured)'
-  } else if (exposeType === 'none') {
-    message += ' It is not exposed externally (exposeType "none").'
   } else {
-    message += ` The ${exposeType} address is still being assigned — call get_app_status shortly, or check the Applications page, for the URL.`
+    message +=
+      ' The URL is still being assigned — call get_app_status shortly, or check the Applications page, for the URL.'
   }
 
   return {

--- a/server/routes/vibe.js
+++ b/server/routes/vibe.js
@@ -1325,40 +1325,37 @@ async function handleVibeManifestExposure(req, res) {
     const content = await fetchFile(conn.payload, branch, gitPath)
     if (!content) return json(res, 404, { error: 'Manifest not found' })
 
-    // Find the Service document
-    const docs = content
-      .split(/^---\s*$/m)
-      .map((d) => d.trim())
-      .filter(Boolean)
-    const svcDoc = docs.find((d) => /^kind:\s*Service/m.test(d))
-    const ingDoc = docs.find((d) => /^kind:\s*Ingress/m.test(d))
+    // Parse every YAML document and locate the Service / Ingress objects.
+    const docs = yaml
+      .loadAll(content)
+      .filter((d) => d && typeof d === 'object')
+    const svc = docs.find((d) => d.kind === 'Service')
+    const ing = docs.find((d) => d.kind === 'Ingress')
 
-    if (!svcDoc) return json(res, 200, { exposeType: 'none' })
+    if (!svc) return json(res, 200, { exposeType: 'none' })
 
-    // Parse type and port from the Service doc using regex (no YAML parser needed)
-    const typeMatch = svcDoc.match(/^\s+type:\s*(\S+)/m)
-    const portMatch = svcDoc.match(/^\s+port:\s*(\d+)/m)
-    const svcType = typeMatch ? typeMatch[1] : 'ClusterIP'
-    const port = portMatch ? Number(portMatch[1]) : 80
+    const svcType = svc.spec?.type || 'ClusterIP'
+    const port = svc.spec?.ports?.[0]?.port ?? 80
 
     let exposeType = 'none'
     if (svcType === 'NodePort') exposeType = 'NodePort'
     else if (svcType === 'LoadBalancer') exposeType = 'LoadBalancer'
-    else if (svcType === 'ClusterIP' && ingDoc) exposeType = 'Ingress'
+    else if (svcType === 'ClusterIP' && ing) exposeType = 'Ingress'
 
     const result = { exposeType, port }
 
-    if (ingDoc) {
-      const hostMatch = ingDoc.match(/^\s+host:\s*(\S+)/m)
-      const pathMatch = ingDoc.match(/^\s+path:\s*(\S+)/m)
+    if (ing) {
+      const rule = ing.spec?.rules?.[0]
+      const host = rule?.host
+      const path = rule?.http?.paths?.[0]?.path
       // Prefer spec.ingressClassName; fall back to the legacy annotation for
       // manifests written before the switch.
-      const classMatch =
-        ingDoc.match(/^\s+ingressClassName:\s*(\S+)/m) ||
-        ingDoc.match(/kubernetes\.io\/ingress\.class:\s*(\S+)/m)
-      if (hostMatch) result.ingHost = hostMatch[1]
-      if (pathMatch) result.ingPath = pathMatch[1]
-      if (classMatch) result.ingClass = classMatch[1]
+      const ingClass =
+        ing.spec?.ingressClassName ||
+        ing.metadata?.annotations?.['kubernetes.io/ingress.class']
+      if (host) result.ingHost = host
+      if (path) result.ingPath = path
+      if (ingClass) result.ingClass = ingClass
     }
 
     return json(res, 200, result)


### PR DESCRIPTION
Closes: R8S-1203

## What & why

Per @neil-cresswell-portainer  direction, we now assume every cluster has an ingress controller, so exposing an app at a **URL via ingress** is the only exposure method. This removes the NodePort and LoadBalancer choices from the UI and the MCP tool, simplifying the deploy experience.

## Changes

### Deploy wizard — Details step (`DetailsStep.tsx`, `DeployPage.tsx`)
- Removed the "Expose as" selector entirely. The step now shows just **Hostname** and **Ingress class**.
- `exposeType` defaults to `Ingress`, and the env-capability probe no longer downgrades it to NodePort/LoadBalancer (it still probes to populate ingress classes and the base domain).

### Service edit tab (`VibeEditTab.tsx`)
- Same treatment: removed the exposure selector, the static readout, and the Path field, leaving **Hostname** + **Ingress class**.
- `exposeType` is now a constant `Ingress`. The existing path value is still loaded and preserved on save (just not editable here).

### MCP `deploy_app` tool (`mcp.js`)
- Dropped the `exposeType` parameter and its enum; deploys are always `Ingress`.
- Removed the now-dead `none`/`NodePort`/`LoadBalancer` handling (default logic, access-URL polling, success-message branches) and updated the guidance text and schema descriptions.

### Bug fix — edit tab loaded a blank hostname (`vibe.js`)
- `GET /api/vibe/manifest-exposure` scraped the manifest YAML with regexes like `/^\s+host:/`, which can't match keys written inline with a list dash (`- host: …`, `- path: …`). Only `ingressClassName` (a plain map key) parsed, so the hostname always came back empty.
- Replaced the regex scraping with a proper `js-yaml` parse, reading `spec.rules[0].host`, `…http.paths[0].path`, and `spec.ingressClassName` (falling back to the legacy annotation). Host/path/class now populate correctly.

### Dev experience (`client/package.json`)
- Dev now runs Vite under `bun --watch`. The backend runs in-process (loaded via a runtime `import()`), and Bun caches ES modules, so server edits previously required a manual restart. `--watch` restarts the process only when files in Bun's module graph change (the server subtree); client `src/**` changes still hot-reload via Vite.

## Testing
- `tsc --noEmit`, ESLint, and Prettier all clean (also enforced by the pre-commit hook).
- Verified the YAML read-back fix end-to-end by serializing a manifest through the real `serializeManifests()` and parsing it back — `host`, `path`, `ingressClass`, and `port` all resolve.
- Confirmed Bun `--watch` restart scoping (imported files trigger a reload; unimported files don't).

## Notes / follow-ups
- The backend still fully supports `Ingress` manifests, so no server-side manifest generation changed.
- `exposeType` remains an internal value (`'Ingress'`) in the deploy payload and serializer; only the user-facing choice was removed.