### PR TITLE
feat(docker): add OCI image labels and build metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,14 @@ jobs:
       - name: '[validation] check server syntax'
         run: node --check server/server.js
 
+      - name: '[preparation] capture git commit'
+        id: git-info
+        run: echo "sha=$(git log -1 --format=%h)" >> "$GITHUB_OUTPUT"
+
+      - name: '[preparation] generate build date'
+        id: build-date
+        run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: '[preparation] set up QEMU'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
@@ -75,6 +83,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             PORTAINER_RUN_VERSION=${{ needs.tag.outputs.value }}
+            GIT_COMMIT=${{ steps.git-info.outputs.sha }}
+            BUILD_DATE=${{ steps.build-date.outputs.date }}
           tags: ${{ env.IMAGE_NAME }}:${{ needs.tag.outputs.value }}
           outputs: type=oci,dest=/tmp/image.tar
 
@@ -117,6 +127,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             PORTAINER_RUN_VERSION=${{ needs.tag.outputs.value }}
+            GIT_COMMIT=${{ steps.git-info.outputs.sha }}
+            BUILD_DATE=${{ steps.build-date.outputs.date }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.tag.outputs.value }}
           sbom: true
           provenance: mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,6 +92,14 @@ jobs:
           submodules: recursive
           token: ${{ steps.fetch-token.outputs.token }}
 
+      - name: '[preparation] capture git commit'
+        id: git-info
+        run: echo "sha=$(git log -1 --format=%h)" >> "$GITHUB_OUTPUT"
+
+      - name: '[preparation] generate build date'
+        id: build-date
+        run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: '[preparation] set up QEMU'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
@@ -114,6 +122,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             PORTAINER_RUN_VERSION=${{ needs.create-release.outputs.version }}
+            GIT_COMMIT=${{ steps.git-info.outputs.sha }}
+            BUILD_DATE=${{ steps.build-date.outputs.date }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create-release.outputs.version }}
           sbom: true
           provenance: mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,18 @@ ENV NODE_ENV=production
 ARG PORTAINER_RUN_VERSION=dev
 ENV PORTAINER_RUN_VERSION=$PORTAINER_RUN_VERSION
 
+# Build metadata, supplied by CI (--build-arg GIT_COMMIT=... BUILD_DATE=...).
+ARG GIT_COMMIT=unspecified
+ARG BUILD_DATE=unspecified
+LABEL git_commit=$GIT_COMMIT \
+  org.opencontainers.image.revision=$GIT_COMMIT \
+  org.opencontainers.image.created=$BUILD_DATE \
+  org.opencontainers.image.version=$PORTAINER_RUN_VERSION \
+  org.opencontainers.image.title="Portainer Run" \
+  org.opencontainers.image.description="Portainer Run - a self-service deployment portal for Kubernetes, backed by the Portainer API." \
+  org.opencontainers.image.vendor="Portainer.io" \
+  org.opencontainers.image.url="https://www.portainer.io" \
+  org.opencontainers.image.documentation="https://docs.portainer.io" \
+  io.portainer.portainer-run="true"
+
 CMD ["node", "server/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Stage 1: Build the Vite client
 FROM node:24-alpine AS build-ui
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,12 @@ RUN npm install --omit=dev
 
 # Stage 3: Slim runtime image
 FROM node:24-alpine AS runtime
+
+# Not needed at runtime (only used to install deps during the build stages) — strip them to
+# shrink the image and reduce CVE surface.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /opt/yarn-v* \
+      /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /usr/local/bin/yarn /usr/local/bin/yarnpkg
+
 RUN apk add --no-cache openssl
 WORKDIR /app
 


### PR DESCRIPTION
- Adds an OCI-standard `LABEL` block to `Dockerfile` (title, description, vendor, url, documentation, revision, created, version) plus an `io.portainer.portainer-run` marker — the image previously had no `LABEL` data at all, which is why Docker Hub's Specifications tab rendered empty for it (unlike `portal-template`/`portainer-ee`, which both carry this metadata).
- Threads new `GIT_COMMIT` and `BUILD_DATE` build-args through `release.yaml`'s `publish-images` job so `org.opencontainers.image.revision`/`.created` populate dynamically, matching the pattern already used in `portal-template`.
- Applies the same build-args to `ci.yaml`'s PR/dev-build image tags too, so develop and PR-built images carry the same metadata as release images.

Related to PLA-846: https://linear.app/portainer/issue/PLA-846/dockerfile-enhancements