### PR TITLE
feat(settings): authenticate to Portainer as the add-on [R8S-1228]

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Browser → TLS-terminating proxy → Node HTTP server (server.js) → Portainer
 
 Portainer-Run is a React and Vite frontend served by a Node HTTP server. The server forwards Kubernetes API calls to Portainer (bypassing browser CORS), relays AI requests to the configured provider (keeping the API key server-side), serves the aggregated `/env-status/` endpoint, exposes the `/mcp` MCP endpoint, and maintains a file-backed session cache.
 
-Its own configuration comes from the same Portainer API: the server fetches it and holds it in memory, so settings are neither baked into the image nor stored in the cluster. Every call to Portainer, including that one, carries the requesting user's credential — Portainer-Run has no identity of its own.
+Its own configuration comes from the same Portainer API: the server fetches it and holds it in memory, so settings are neither baked into the image nor stored in the cluster. Calls made on a user's behalf carry that user's credential. Reading its own settings uses the credential Portainer issues the add-on — a token mounted as a Secret in its namespace, good for that one API and nothing else.
 
 User credentials never appear in server logs. AI API keys never reach the browser.
 
@@ -174,13 +174,13 @@ The server maintains a SQLite database at `data/portainer-run.db` for git target
 
 ## Setup and configuration
 
-Portainer-Run's configuration lives in Portainer, not in the chart and not in Kubernetes. Portainer holds the values; Portainer-Run fetches them over Portainer's API and keeps them in memory. Nothing is written into the cluster, so there is no Secret to manage, no Helm value to set, and no redeploy when a setting changes.
+Portainer-Run's configuration lives in Portainer, not in the chart and not in Kubernetes. Portainer holds the values; Portainer-Run fetches them over Portainer's API and keeps them in memory. No setting is written into the cluster, so there is no Secret to manage, no Helm value to set, and no redeploy when a setting changes.
 
 `ENCRYPTION_KEY` is the clearest example. It is generated inside Portainer-Run during first-run setup, saved to Portainer's database, and read back from there whenever Portainer-Run needs it. An operator never generates it, never copies it into a values file, and never has to keep it identical across upgrades by hand.
 
 Two consequences follow from settings being memory-only:
 
-- **A restart begins unconfigured.** Portainer-Run has no credential of its own and Portainer's settings endpoints are administrator-only, so it cannot fetch on its own behalf at boot. It borrows an administrator's token instead: the setup screen asks it to load settings the moment they are saved, and any administrator request re-loads them opportunistically. In practice a restarted pod configures itself as soon as an admin uses it. A machine credential (mTLS) will remove this gap.
+- **A restart refetches at boot.** Portainer issues Portainer-Run a credential of its own, mounted as a Secret in its namespace, and the server uses it to fetch settings at startup with no user behind the request.
 - **Settings never enter Helm.** Helm keeps every retained revision's values in cleartext inside its own `sh.helm.release.*` Secrets, so a key passed as a chart value would linger in release history long after it was rotated. Keeping configuration out of Helm avoids that entirely.
 
 ### First-run setup
@@ -190,8 +190,8 @@ A fresh install starts with no `ENCRYPTION_KEY` and boots into an **awaiting set
 An administrator opens Portainer-Run and completes setup:
 
 1. The setup screen generates an `ENCRYPTION_KEY` in the browser using the Web Crypto CSPRNG.
-2. It saves the value to Portainer over the administrator's own session. Portainer-Run holds no credential and never performs this write itself.
-3. It asks Portainer-Run to load its settings, which it does using that same administrator's token.
+2. It saves the value to Portainer over the administrator's own session, never through Portainer-Run: adopting a key is a deliberate act, and Portainer records who made it.
+3. It asks Portainer-Run to load its settings, which it does with its own credential.
 4. Portainer-Run is configured. No restart, no redeploy.
 
 The key is only needed _after_ setup, for encrypting Git target credentials and deriving the gateway identity, so generating it before Portainer-Run holds it presents no ordering problem.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -160,3 +160,10 @@ honored — `default` would treat 0/"" as empty and silently restore the fallbac
 {{- $c := .Values.configMap | default dict -}}
 {{- if hasKey $c "PORT" }}{{ $c.PORT }}{{ else }}8080{{ end -}}
 {{- end }}
+
+{{- /* Where Portainer's credential is mounted. One definition for the volume
+mount and the server that reads it, so the two cannot drift. */}}
+{{- define "portainer-run.credentialDir" -}}
+{{- $c := .Values.configMap | default dict -}}
+{{- if hasKey $c "MACHINE_CREDENTIAL_DIR" }}{{ $c.MACHINE_CREDENTIAL_DIR }}{{ else }}/var/run/secrets/portainer/addon{{ end -}}
+{{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -10,8 +10,9 @@ data:
   # Baked-in defaults (kept out of values.yaml; see _helpers.tpl).
   PORTAINER_URL: {{ include "portainer-run.portainerUrl" . | quote }}
   PORT: {{ include "portainer-run.port" . | quote }}
+  MACHINE_CREDENTIAL_DIR: {{ include "portainer-run.credentialDir" . | quote }}
   {{- range $key, $value := .Values.configMap }}
-  {{- if not (has $key (list "PORTAINER_URL" "PORT")) }}
+  {{- if not (has $key (list "PORTAINER_URL" "PORT" "MACHINE_CREDENTIAL_DIR")) }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               running pod without a restart.
             */}}
             - name: portainer-credential
-              mountPath: /var/run/secrets/portainer/addon
+              mountPath: {{ include "portainer-run.credentialDir" . | quote }}
               readOnly: true
           resources:
             requests:
@@ -84,7 +84,13 @@ spec:
             claimName: {{ include "portainer-run.cacheClaimName" . }}
         - name: portainer-credential
           secret:
+            # Fixed name: Portainer derives it from the add-on id in its catalog
+            # and creates the Secret itself, so this cannot be templated off the
+            # release name without breaking the mount.
             secretName: portainer-run-token
             # Absent where Portainer has not issued a credential; the server
             # borrows an admin caller's token instead.
             optional: true
+            # Readable only by the container's own user. Root today, so this is
+            # readable as written; a non-root user would need a matching fsGroup.
+            defaultMode: 0400

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -47,6 +47,14 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /app/data
+            {{- /*
+              Mounted rather than envFrom because the kubelet refreshes a mounted
+              Secret in place, which is what lets a repaired credential reach a
+              running pod without a restart.
+            */}}
+            - name: portainer-credential
+              mountPath: /var/run/secrets/portainer/addon
+              readOnly: true
           resources:
             requests:
               cpu: 50m
@@ -74,3 +82,9 @@ spec:
         - name: cache
           persistentVolumeClaim:
             claimName: {{ include "portainer-run.cacheClaimName" . }}
+        - name: portainer-credential
+          secret:
+            secretName: portainer-run-token
+            # Absent where Portainer has not issued a credential; the server
+            # borrows an admin caller's token instead.
+            optional: true

--- a/server/config.js
+++ b/server/config.js
@@ -35,6 +35,9 @@ export const PORTAINER_URL = (process.env.PORTAINER_URL || '').replace(
 export const PORT = parseInt(process.env.PORT || '8080', 10)
 export const CACHE_DIR = process.env.CACHE_DIR || path.join(projectRoot, 'data')
 
+export const MACHINE_CREDENTIAL_DIR =
+  process.env.MACHINE_CREDENTIAL_DIR || '/var/run/secrets/portainer/addon'
+
 /** Release version, baked in at Docker build time. 'dev' for local/non-release builds. */
 export const VERSION = process.env.PORTAINER_RUN_VERSION || 'dev'
 

--- a/server/env-status.js
+++ b/server/env-status.js
@@ -1,11 +1,9 @@
-import http from 'node:http'
-import https from 'node:https'
 import crypto from 'node:crypto'
 import { CORS } from './lib/cors.js'
 import { createLimiter } from './lib/limit.js'
 import { resolvePortainerTarget } from './resolve-portainer.js'
 import { extractToken, portainerAuthHeaders } from './lib/identity.js'
-import { portainerTlsOptions, boundRequest } from './lib/portainer-tls.js'
+import { portainerHttpRequest } from './lib/portainer-tls.js'
 
 const STATUS_TTL = 5 * 1000
 
@@ -22,37 +20,31 @@ function kubeCall(token, envId, kubePath, target) {
   return kubeLimit(
     () =>
       new Promise((resolve, reject) => {
-        const upPath = `/api/endpoints/${envId}/kubernetes${kubePath}`
         const headers = {
           Accept: 'application/json',
           ...portainerAuthHeaders(token),
         }
-        const transport = target.isHttps ? https : http
-        const req = boundRequest(
-          transport.request(
-            {
-              hostname: target.host,
-              port: target.port,
-              path: upPath,
-              method: 'GET',
-              headers,
-              ...portainerTlsOptions(),
-            },
-            (res) => {
-              const chunks = []
-              res.on('data', (c) => chunks.push(c))
-              res.on('end', () => {
-                try {
-                  resolve({
-                    status: res.statusCode,
-                    body: JSON.parse(Buffer.concat(chunks).toString('utf8')),
-                  })
-                } catch {
-                  resolve({ status: res.statusCode, body: {} })
-                }
-              })
-            },
-          ),
+        const req = portainerHttpRequest(
+          target,
+          {
+            path: `/api/endpoints/${envId}/kubernetes${kubePath}`,
+            method: 'GET',
+            headers,
+          },
+          (res) => {
+            const chunks = []
+            res.on('data', (c) => chunks.push(c))
+            res.on('end', () => {
+              try {
+                resolve({
+                  status: res.statusCode,
+                  body: JSON.parse(Buffer.concat(chunks).toString('utf8')),
+                })
+              } catch {
+                resolve({ status: res.statusCode, body: {} })
+              }
+            })
+          },
         )
         req.on('error', reject)
         req.end()

--- a/server/env-status.js
+++ b/server/env-status.js
@@ -5,6 +5,7 @@ import { CORS } from './lib/cors.js'
 import { createLimiter } from './lib/limit.js'
 import { resolvePortainerTarget } from './resolve-portainer.js'
 import { extractToken, portainerAuthHeaders } from './lib/identity.js'
+import { portainerTlsOptions, boundRequest } from './lib/portainer-tls.js'
 
 const STATUS_TTL = 5 * 1000
 
@@ -27,29 +28,31 @@ function kubeCall(token, envId, kubePath, target) {
           ...portainerAuthHeaders(token),
         }
         const transport = target.isHttps ? https : http
-        const req = transport.request(
-          {
-            hostname: target.host,
-            port: target.port,
-            path: upPath,
-            method: 'GET',
-            headers,
-            rejectUnauthorized: false,
-          },
-          (res) => {
-            const chunks = []
-            res.on('data', (c) => chunks.push(c))
-            res.on('end', () => {
-              try {
-                resolve({
-                  status: res.statusCode,
-                  body: JSON.parse(Buffer.concat(chunks).toString('utf8')),
-                })
-              } catch {
-                resolve({ status: res.statusCode, body: {} })
-              }
-            })
-          },
+        const req = boundRequest(
+          transport.request(
+            {
+              hostname: target.host,
+              port: target.port,
+              path: upPath,
+              method: 'GET',
+              headers,
+              ...portainerTlsOptions(),
+            },
+            (res) => {
+              const chunks = []
+              res.on('data', (c) => chunks.push(c))
+              res.on('end', () => {
+                try {
+                  resolve({
+                    status: res.statusCode,
+                    body: JSON.parse(Buffer.concat(chunks).toString('utf8')),
+                  })
+                } catch {
+                  resolve({ status: res.statusCode, body: {} })
+                }
+              })
+            },
+          ),
         )
         req.on('error', reject)
         req.end()

--- a/server/handler.js
+++ b/server/handler.js
@@ -7,11 +7,11 @@ import {
   aiProvider,
   anthropicKey,
   baseDomain,
+  credentialFault,
   credentialHealth,
   ensureHydrated,
   isConfigured,
   openaiKey,
-  retryFailedHydration,
 } from './settings.js'
 import { hasMachineCredential } from './machine-credential.js'
 import { keyContinuity } from './lib/key-continuity.js'
@@ -62,19 +62,31 @@ export async function handleRequest(req, res) {
   // probes: this one answers 401 so Portainer can offer a repair, where a
   // Kubernetes probe would restart the pod and fix nothing.
   if (pathname === '/healthz') {
-    // Portainer polls this, so let its probe pick up a repaired Secret.
-    retryFailedHydration()
+    // Portainer polls this, so let its probe pick up a repaired Secret. Not
+    // awaited, so the probe does not wait on a round trip to answer.
+    void ensureHydrated().catch(() => {})
 
     const status = credentialHealth()
     const code = { ok: 200, 'credential-invalid': 401 }[status] ?? 503
 
-    res.writeHead(code, { 'Content-Type': 'application/json', ...CORS })
+    res.writeHead(code, {
+      'Content-Type': 'application/json',
+      // A 401 must carry a challenge. This one names the add-on's own
+      // credential, which no caller can supply.
+      ...(code === 401
+        ? { 'WWW-Authenticate': 'Bearer realm="portainer-addon"' }
+        : {}),
+      ...CORS,
+    })
     res.end(
       JSON.stringify({
         status,
         hasCredential: hasMachineCredential(),
         configured: isConfigured(),
         version: VERSION,
+        // Which half failed, not why: this endpoint is unauthenticated, so the
+        // upstream message stays on /api/setup/status with the other details.
+        fault: credentialFault(),
       }),
     )
     return
@@ -149,11 +161,11 @@ export async function handleRequest(req, res) {
   }
 
   // This already ran at startup; retrying recovers a Portainer that was down
-  // then. Only without a credential do we still borrow an admin caller's token.
+  // then. Only without a credential do we borrow an admin caller's token, which
+  // costs an identity lookup this path would otherwise not need.
   if (!isConfigured() && pathname.startsWith('/api/')) {
-    if (hasMachineCredential()) {
-      await ensureHydrated()
-    } else {
+    if (hasMachineCredential()) await ensureHydrated()
+    else {
       const caller = await resolveCallerIdentity(req)
       if (caller?.isAdmin) await ensureHydrated(caller.token)
     }

--- a/server/handler.js
+++ b/server/handler.js
@@ -7,10 +7,13 @@ import {
   aiProvider,
   anthropicKey,
   baseDomain,
+  credentialHealth,
   ensureHydrated,
   isConfigured,
   openaiKey,
+  retryFailedHydration,
 } from './settings.js'
+import { hasMachineCredential } from './machine-credential.js'
 import { keyContinuity } from './lib/key-continuity.js'
 import { handleCache } from './cache.js'
 import { handleEnvStatus } from './env-status.js'
@@ -52,6 +55,28 @@ export async function handleRequest(req, res) {
   ) {
     res.writeHead(403, { 'Content-Type': 'application/json', ...CORS })
     res.end(JSON.stringify({ error: 'Cross-site request blocked' }))
+    return
+  }
+
+  // Portainer's own health probe, kept apart from the /config that Kubernetes
+  // probes: this one answers 401 so Portainer can offer a repair, where a
+  // Kubernetes probe would restart the pod and fix nothing.
+  if (pathname === '/healthz') {
+    // Portainer polls this, so let its probe pick up a repaired Secret.
+    retryFailedHydration()
+
+    const status = credentialHealth()
+    const code = { ok: 200, 'credential-invalid': 401 }[status] ?? 503
+
+    res.writeHead(code, { 'Content-Type': 'application/json', ...CORS })
+    res.end(
+      JSON.stringify({
+        status,
+        hasCredential: hasMachineCredential(),
+        configured: isConfigured(),
+        version: VERSION,
+      }),
+    )
     return
   }
 
@@ -123,11 +148,15 @@ export async function handleRequest(req, res) {
     if (handled !== null) return
   }
 
-  // Settings are memory-only, so a restart starts unconfigured. Borrow the
-  // first admin caller's token rather than waiting for the setup screen.
+  // This already ran at startup; retrying recovers a Portainer that was down
+  // then. Only without a credential do we still borrow an admin caller's token.
   if (!isConfigured() && pathname.startsWith('/api/')) {
-    const caller = await resolveCallerIdentity(req)
-    if (caller?.isAdmin) await ensureHydrated(caller.token)
+    if (hasMachineCredential()) {
+      await ensureHydrated()
+    } else {
+      const caller = await resolveCallerIdentity(req)
+      if (caller?.isAdmin) await ensureHydrated(caller.token)
+    }
   }
 
   // These decrypt stored credentials, so without a key they would 500.

--- a/server/lib/identity.js
+++ b/server/lib/identity.js
@@ -2,13 +2,15 @@ import https from 'node:https'
 import http from 'node:http'
 import { getCachedUser, setCachedUser } from './userCache.js'
 import { resolvePortainerTarget } from '../resolve-portainer.js'
+import { portainerTlsOptions, boundRequest } from './portainer-tls.js'
 
 /**
  * Build the outbound auth header for a call to Portainer, matching the token
- * type: API access tokens ("ptr_" prefix) go on X-API-Key, session JWTs on
- * Authorization: Bearer. Only the matching header is sent — Portainer's
- * apiKeyLookup runs first and 401s if X-API-Key holds a JWT. A JWT must never
- * be sent as the portainer_api_key cookie: core's CSRF check fails closed on
+ * type: API access tokens ("ptr_" prefix) go on X-API-Key, session JWTs and
+ * this add-on's machine token ("paddon_") on Authorization: Bearer, which is
+ * the only header the machine API reads. Only the matching header is sent —
+ * Portainer's apiKeyLookup runs first and 401s if X-API-Key holds a JWT. A JWT
+ * must never be sent as the portainer_api_key cookie: core's CSRF check fails closed on
  * unsafe cookie-authenticated requests lacking Origin/Sec-Fetch-Site (which
  * server-to-server calls never send), but exempts token auth.
  * @param {string} token
@@ -29,29 +31,32 @@ export function portainerAuthHeaders(token) {
 export function portainerGet(target, token, path) {
   return new Promise((resolve, reject) => {
     const mod = target.isHttps ? https : http
-    const req = mod.request(
-      {
-        hostname: target.host,
-        port: target.port,
-        path,
-        method: 'GET',
-        headers: {
-          ...portainerAuthHeaders(token),
-          'Content-Type': 'application/json',
+    const req = boundRequest(
+      mod.request(
+        {
+          hostname: target.host,
+          port: target.port,
+          path,
+          method: 'GET',
+          headers: {
+            ...portainerAuthHeaders(token),
+            'Content-Type': 'application/json',
+          },
+          // Answers "is the caller an administrator?", so a forged reply grants it.
+          ...portainerTlsOptions(),
         },
-        rejectUnauthorized: false,
-      },
-      (res) => {
-        let body = ''
-        res.on('data', (c) => (body += c))
-        res.on('end', () => {
-          try {
-            resolve(JSON.parse(body))
-          } catch {
-            reject(new Error('Invalid JSON from Portainer'))
-          }
-        })
-      },
+        (res) => {
+          let body = ''
+          res.on('data', (c) => (body += c))
+          res.on('end', () => {
+            try {
+              resolve(JSON.parse(body))
+            } catch {
+              reject(new Error('Invalid JSON from Portainer'))
+            }
+          })
+        },
+      ),
     )
     req.on('error', reject)
     req.end()

--- a/server/lib/identity.js
+++ b/server/lib/identity.js
@@ -1,8 +1,6 @@
-import https from 'node:https'
-import http from 'node:http'
 import { getCachedUser, setCachedUser } from './userCache.js'
 import { resolvePortainerTarget } from '../resolve-portainer.js'
-import { portainerTlsOptions, boundRequest } from './portainer-tls.js'
+import { portainerHttpRequest } from './portainer-tls.js'
 
 /**
  * Build the outbound auth header for a call to Portainer, matching the token
@@ -30,33 +28,28 @@ export function portainerAuthHeaders(token) {
  */
 export function portainerGet(target, token, path) {
   return new Promise((resolve, reject) => {
-    const mod = target.isHttps ? https : http
-    const req = boundRequest(
-      mod.request(
-        {
-          hostname: target.host,
-          port: target.port,
-          path,
-          method: 'GET',
-          headers: {
-            ...portainerAuthHeaders(token),
-            'Content-Type': 'application/json',
-          },
-          // Answers "is the caller an administrator?", so a forged reply grants it.
-          ...portainerTlsOptions(),
+    // Answers "is the caller an administrator?", so a forged reply grants it.
+    const req = portainerHttpRequest(
+      target,
+      {
+        path,
+        method: 'GET',
+        headers: {
+          ...portainerAuthHeaders(token),
+          'Content-Type': 'application/json',
         },
-        (res) => {
-          let body = ''
-          res.on('data', (c) => (body += c))
-          res.on('end', () => {
-            try {
-              resolve(JSON.parse(body))
-            } catch {
-              reject(new Error('Invalid JSON from Portainer'))
-            }
-          })
-        },
-      ),
+      },
+      (res) => {
+        let body = ''
+        res.on('data', (c) => (body += c))
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(body))
+          } catch {
+            reject(new Error('Invalid JSON from Portainer'))
+          }
+        })
+      },
     )
     req.on('error', reject)
     req.end()

--- a/server/lib/portainer-api.js
+++ b/server/lib/portainer-api.js
@@ -1,13 +1,14 @@
 import https from 'node:https'
 import http from 'node:http'
 import { portainerAuthHeaders } from './identity.js'
+import { portainerTlsOptions, boundRequest } from './portainer-tls.js'
 
 /**
- * Request Portainer's API as a caller. `userToken` is always the inbound
- * caller's own credential — Portainer-Run has no identity of its own.
+ * Request Portainer's API. `token` is either the inbound caller's own
+ * credential or this add-on's machine token.
  *
  * @param {{ host: string, port: number, isHttps: boolean }} target
- * @param {string} userToken
+ * @param {string} token
  * @param {string} method
  * @param {string} path
  * @param {string} [body]
@@ -15,7 +16,7 @@ import { portainerAuthHeaders } from './identity.js'
  */
 export function portainerRequest(
   target,
-  userToken,
+  token,
   method,
   path,
   body,
@@ -24,7 +25,7 @@ export function portainerRequest(
   return new Promise((resolve, reject) => {
     const transport = target.isHttps ? https : http
     const headers = { 'Content-Type': contentType, Accept: 'application/json' }
-    if (userToken) Object.assign(headers, portainerAuthHeaders(userToken))
+    if (token) Object.assign(headers, portainerAuthHeaders(token))
     if (body) headers['Content-Length'] = Buffer.byteLength(body)
 
     const opts = {
@@ -33,40 +34,42 @@ export function portainerRequest(
       path,
       method,
       headers,
-      rejectUnauthorized: false,
+      ...portainerTlsOptions(),
     }
 
-    const reqOut = transport.request(opts, (upRes) => {
-      const chunks = []
-      upRes.on('data', (c) => chunks.push(c))
-      upRes.on('end', () => {
-        const text = Buffer.concat(chunks).toString('utf8')
-        if (upRes.statusCode >= 400) {
-          // Keep the method/path/status alongside Portainer's own message so a
-          // routing 404 ("Not Found") is distinguishable from a resource 404.
-          let detail = ''
-          try {
-            const parsed = JSON.parse(text)
-            detail = parsed?.message || parsed?.details || ''
-          } catch {
-            /* ignore */
+    const reqOut = boundRequest(
+      transport.request(opts, (upRes) => {
+        const chunks = []
+        upRes.on('data', (c) => chunks.push(c))
+        upRes.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf8')
+          if (upRes.statusCode >= 400) {
+            // Keep the method/path/status alongside Portainer's own message so a
+            // routing 404 ("Not Found") is distinguishable from a resource 404.
+            let detail = ''
+            try {
+              const parsed = JSON.parse(text)
+              detail = parsed?.message || parsed?.details || ''
+            } catch {
+              /* ignore */
+            }
+            const err = new Error(
+              `Portainer ${method} ${path.split('?')[0]} → HTTP ${upRes.statusCode}` +
+                (detail ? `: ${detail}` : ''),
+            )
+            err.status = upRes.statusCode
+            err.method = method
+            err.url = path.split('?')[0]
+            return reject(err)
           }
-          const err = new Error(
-            `Portainer ${method} ${path.split('?')[0]} → HTTP ${upRes.statusCode}` +
-              (detail ? `: ${detail}` : ''),
-          )
-          err.status = upRes.statusCode
-          err.method = method
-          err.url = path.split('?')[0]
-          return reject(err)
-        }
-        try {
-          resolve(JSON.parse(text))
-        } catch {
-          resolve(text)
-        }
-      })
-    })
+          try {
+            resolve(JSON.parse(text))
+          } catch {
+            resolve(text)
+          }
+        })
+      }),
+    )
 
     reqOut.on('error', reject)
     if (body) reqOut.write(body)

--- a/server/lib/portainer-api.js
+++ b/server/lib/portainer-api.js
@@ -1,7 +1,5 @@
-import https from 'node:https'
-import http from 'node:http'
 import { portainerAuthHeaders } from './identity.js'
-import { portainerTlsOptions, boundRequest } from './portainer-tls.js'
+import { portainerHttpRequest } from './portainer-tls.js'
 
 /**
  * Request Portainer's API. `token` is either the inbound caller's own
@@ -23,22 +21,14 @@ export function portainerRequest(
   contentType = 'application/json',
 ) {
   return new Promise((resolve, reject) => {
-    const transport = target.isHttps ? https : http
     const headers = { 'Content-Type': contentType, Accept: 'application/json' }
     if (token) Object.assign(headers, portainerAuthHeaders(token))
     if (body) headers['Content-Length'] = Buffer.byteLength(body)
 
-    const opts = {
-      hostname: target.host,
-      port: target.port,
-      path,
-      method,
-      headers,
-      ...portainerTlsOptions(),
-    }
-
-    const reqOut = boundRequest(
-      transport.request(opts, (upRes) => {
+    const reqOut = portainerHttpRequest(
+      target,
+      { path, method, headers },
+      (upRes) => {
         const chunks = []
         upRes.on('data', (c) => chunks.push(c))
         upRes.on('end', () => {
@@ -68,7 +58,7 @@ export function portainerRequest(
             resolve(text)
           }
         })
-      }),
+      },
     )
 
     reqOut.on('error', reject)

--- a/server/lib/portainer-tls.js
+++ b/server/lib/portainer-tls.js
@@ -135,6 +135,9 @@ function verifyPeer(req, socket) {
   const ca = portainerCA()
   if (!ca) return
 
+  // Validity dates are not checked here. They bound how long a chain vouches
+  // for a binding this does not rely on, and expiry has no republishing of its
+  // own — a Repair would hand back the same certificate, with no way out.
   const leaf = socket.getPeerCertificate(false)?.raw
   if (leaf && publishedCertificates(ca).some((der) => der.equals(leaf))) return
 

--- a/server/lib/portainer-tls.js
+++ b/server/lib/portainer-tls.js
@@ -1,41 +1,154 @@
 /**
- * How this add-on trusts and bounds its calls to Portainer. Shared by every
- * outbound client, so none can be left on weaker terms than the others.
+ * How this add-on trusts and bounds its calls to Portainer. Every outbound
+ * client goes through portainerHttpRequest, so none can be left on weaker terms
+ * than the others.
  */
 
-import tls from 'node:tls'
-import { portainerCA } from '../machine-credential.js'
+import https from 'node:https'
+import http from 'node:http'
+import { portainerCA, portainerCAUnreadable } from '../machine-credential.js'
 
 /** Without this, a blackholed Portainer hangs every request queued behind it. */
-export const PORTAINER_TIMEOUT_MS = 10_000
+const READ_TIMEOUT_MS = 10_000
 
 /**
- * Verify Portainer against the certificate it published with the credential.
- *
- * The hostname check cannot be turned off for a certificate that does not
- * name the in-cluster service. Node treats every certificate in `ca` as a
- * trust anchor, and Portainer publishes whatever serves its TLS — often a chain
- * including a public intermediate — so skipping it would accept anything that
- * issuer ever signed, for any domain.
- *
- * So a mismatch is allowed only for the certificate we were handed: a renewed
- * one is still checked against its SANs, and one merely sharing an issuer is
- * rejected.
+ * A write can be Portainer cloning a repository and applying manifests inline,
+ * which routinely outlasts a read.
  */
-export function portainerTlsOptions() {
-  const ca = portainerCA()
-  if (!ca) return { rejectUnauthorized: false }
+const WRITE_TIMEOUT_MS = 120_000
 
-  const published = publishedCertificates(ca)
+function timeoutFor(method) {
+  return method === 'GET' ? READ_TIMEOUT_MS : WRITE_TIMEOUT_MS
+}
 
-  return {
-    ca,
-    rejectUnauthorized: true,
-    checkServerIdentity: (hostname, cert) =>
-      published.some((der) => der.equals(cert.raw))
-        ? undefined
-        : tls.checkServerIdentity(hostname, cert),
+/**
+ * A resumed TLS session skips the Certificate message, so getPeerCertificate()
+ * comes back empty and the pin has nothing to match — failing exactly the
+ * certificates the pin exists to accept. maxCachedSessions: 0 keeps every
+ * handshake full; sockets are still pooled.
+ */
+const secureAgent = new https.Agent({ keepAlive: true, maxCachedSessions: 0 })
+
+/**
+ * Make a request to Portainer, verified and bounded.
+ *
+ * @param {{ host: string, port: number, isHttps: boolean }} target
+ * @param {{ path: string, method: string, headers?: object, timeoutMs?: number }} options
+ * @param {(res: import('http').IncomingMessage) => void} onResponse
+ * @returns {import('http').ClientRequest}
+ */
+export function portainerHttpRequest(target, options, onResponse) {
+  const { timeoutMs = timeoutFor(options.method), ...rest } = options
+  const transport = target.isHttps ? https : http
+
+  const req = transport.request(
+    {
+      hostname: target.host,
+      port: target.port,
+      ...rest,
+      ...tlsOptions(target),
+    },
+    onResponse,
+  )
+
+  // A certificate that exists but will not open leaves nothing to verify
+  // against, so the token must not go out over that connection.
+  if (target.isHttps && portainerCAUnreadable()) {
+    const err = new Error(
+      'The published Portainer certificate cannot be read, so this connection cannot be verified',
+    )
+    err.code = 'PORTAINER_CERT_UNREADABLE'
+    req.destroy(err)
+
+    return req
   }
+
+  bound(req, timeoutMs)
+  verifyOnConnect(req)
+
+  return req
+}
+
+/**
+ * Connection options for a call to Portainer. verifyPeer decides, not the
+ * handshake: OpenSSL will not treat a leaf as a trust anchor — no
+ * X509_V_FLAG_PARTIAL_CHAIN — so demanding a verified chain rejects the
+ * ordinary case of a certificate file holding just the serving certificate.
+ */
+function tlsOptions(target) {
+  if (!target.isHttps) return {}
+
+  const ca = portainerCA()
+
+  return ca
+    ? { ca, rejectUnauthorized: false, agent: secureAgent }
+    : { rejectUnauthorized: false, agent: secureAgent }
+}
+
+/**
+ * Bound the whole call, not one phase of it.
+ *
+ * req.setTimeout cannot: Node defers arming it until the socket emits
+ * 'connect', so a peer that drops the SYN is never bounded, and on TLS it arms
+ * on both the TCP and the TLS socket so it fires at twice the value asked for.
+ *
+ * This bounds total duration where req.setTimeout bounds inactivity. Every call
+ * here reads one buffered response, so nothing arrives in instalments for an
+ * inactivity timer to distinguish.
+ */
+function bound(req, timeoutMs) {
+  const timer = setTimeout(() => {
+    const err = new Error('Portainer did not respond in time')
+    err.code = 'PORTAINER_TIMEOUT'
+    req.destroy(err)
+  }, timeoutMs)
+  timer.unref()
+
+  req.on('close', () => clearTimeout(timer))
+}
+
+/**
+ * Verify Portainer's certificate once the handshake completes.
+ *
+ * Nothing is written before this runs: Node emits secureConnect before the
+ * request is flushed, so a rejected peer never sees the token.
+ */
+function verifyOnConnect(req) {
+  req.on('socket', (socket) => {
+    // A pooled socket was verified when it was opened; listening again adds a
+    // listener per request that can never fire.
+    if (!socket.encrypted || !socket.connecting) return
+
+    socket.once('secureConnect', () => verifyPeer(req, socket))
+  })
+}
+
+/**
+ * Accepted on either of two grounds: the certificate is the one published with
+ * the credential, identified by its own bytes, or it verifies normally against
+ * the published one. The second admits a renewal only where the published file
+ * carries the issuer; against a published leaf alone, a renewed certificate is
+ * rejected until Portainer republishes it.
+ */
+function verifyPeer(req, socket) {
+  // Nothing published to verify against; warnUnverified says so at startup.
+  const ca = portainerCA()
+  if (!ca) return
+
+  const leaf = socket.getPeerCertificate(false)?.raw
+  if (leaf && publishedCertificates(ca).some((der) => der.equals(leaf))) return
+
+  if (socket.authorized) return
+
+  const err = new Error(
+    "Portainer's TLS certificate is neither the one published with the add-on " +
+      `credential nor verifiable against it (${socket.authorizationError}). ` +
+      'Repairing the credential republishes the certificate Portainer is currently serving.',
+  )
+  // Carries CERT so failureCause reads it as a credential fault rather than an
+  // unexplained transport error.
+  err.code = 'PORTAINER_CERT_UNTRUSTED'
+  req.destroy(err)
 }
 
 function publishedCertificates(pem) {
@@ -52,11 +165,20 @@ function publishedCertificates(pem) {
   )
 }
 
-/** Fail a request Portainer never answers, like any other transport error. */
-export function boundRequest(req) {
-  req.setTimeout(PORTAINER_TIMEOUT_MS, () =>
-    req.destroy(new Error('Portainer did not respond in time')),
-  )
+/** Report at startup where HTTPS calls stand. */
+export function warnUnverified(isHttps) {
+  if (!isHttps) return
 
-  return req
+  if (portainerCAUnreadable()) {
+    console.warn(
+      '⚠️  The mounted Portainer certificate cannot be read: calls to Portainer will be refused.',
+    )
+    return
+  }
+
+  if (portainerCA()) return
+
+  console.warn(
+    '⚠️  No Portainer certificate is mounted: HTTPS calls to Portainer are not verified.',
+  )
 }

--- a/server/lib/portainer-tls.js
+++ b/server/lib/portainer-tls.js
@@ -1,0 +1,62 @@
+/**
+ * How this add-on trusts and bounds its calls to Portainer. Shared by every
+ * outbound client, so none can be left on weaker terms than the others.
+ */
+
+import tls from 'node:tls'
+import { portainerCA } from '../machine-credential.js'
+
+/** Without this, a blackholed Portainer hangs every request queued behind it. */
+export const PORTAINER_TIMEOUT_MS = 10_000
+
+/**
+ * Verify Portainer against the certificate it published with the credential.
+ *
+ * The hostname check cannot be turned off for a certificate that does not
+ * name the in-cluster service. Node treats every certificate in `ca` as a
+ * trust anchor, and Portainer publishes whatever serves its TLS — often a chain
+ * including a public intermediate — so skipping it would accept anything that
+ * issuer ever signed, for any domain.
+ *
+ * So a mismatch is allowed only for the certificate we were handed: a renewed
+ * one is still checked against its SANs, and one merely sharing an issuer is
+ * rejected.
+ */
+export function portainerTlsOptions() {
+  const ca = portainerCA()
+  if (!ca) return { rejectUnauthorized: false }
+
+  const published = publishedCertificates(ca)
+
+  return {
+    ca,
+    rejectUnauthorized: true,
+    checkServerIdentity: (hostname, cert) =>
+      published.some((der) => der.equals(cert.raw))
+        ? undefined
+        : tls.checkServerIdentity(hostname, cert),
+  }
+}
+
+function publishedCertificates(pem) {
+  const blocks =
+    pem
+      .toString('utf8')
+      .match(/-----BEGIN CERTIFICATE-----[^-]+-----END CERTIFICATE-----/g) ?? []
+
+  return blocks.map((block) =>
+    Buffer.from(
+      block.replace(/-----[^-]+-----/g, '').replace(/\s+/g, ''),
+      'base64',
+    ),
+  )
+}
+
+/** Fail a request Portainer never answers, like any other transport error. */
+export function boundRequest(req) {
+  req.setTimeout(PORTAINER_TIMEOUT_MS, () =>
+    req.destroy(new Error('Portainer did not respond in time')),
+  )
+
+  return req
+}

--- a/server/machine-credential.js
+++ b/server/machine-credential.js
@@ -1,0 +1,38 @@
+/**
+ * Portainer-Run's own credential, mounted by Portainer as a Secret in this
+ * add-on's namespace. It is what lets the server read its settings without
+ * borrowing an administrator's token.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { MACHINE_CREDENTIAL_DIR } from './config.js'
+
+const TOKEN_FILE = 'token'
+const CA_FILE = 'ca.crt'
+
+/**
+ * Read a file from the mounted credential, or null when absent. Never cached:
+ * repairing in Portainer replaces the Secret and the kubelet updates the mount
+ * in place, so caching would lock the pod out until a restart.
+ */
+function read(name) {
+  try {
+    return fs.readFileSync(path.join(MACHINE_CREDENTIAL_DIR, name))
+  } catch {
+    return null
+  }
+}
+
+export function machineToken() {
+  return read(TOKEN_FILE)?.toString('utf8').trim() || ''
+}
+
+/** Portainer's own TLS certificate, or null where it serves plain HTTP. */
+export function portainerCA() {
+  return read(CA_FILE)
+}
+
+export function hasMachineCredential() {
+  return machineToken() !== ''
+}

--- a/server/machine-credential.js
+++ b/server/machine-credential.js
@@ -12,27 +12,106 @@ const TOKEN_FILE = 'token'
 const CA_FILE = 'ca.crt'
 
 /**
- * Read a file from the mounted credential, or null when absent. Never cached:
- * repairing in Portainer replaces the Secret and the kubelet updates the mount
- * in place, so caching would lock the pod out until a restart.
+ * One entry per file: what it last held, or the error that stopped it opening.
+ * An absent file is neither — it is the ordinary no-credential case.
+ *
+ * @typedef {{
+ *   content: Buffer | null,
+ *   error: NodeJS.ErrnoException | null,
+ *   mtimeMs?: number,
+ *   size?: number,
+ * }} CredentialFile
+ * @type {Map<string, CredentialFile>}
+ */
+const files = new Map()
+const reported = new Set()
+
+/**
+ * Read a file from the mounted credential, re-reading when its mtime or size
+ * changes. Repairing in Portainer replaces the Secret and the kubelet swaps the
+ * mount in place, so a copy held outright would lock the pod out until a
+ * restart.
+ *
+ * @param {string} name
+ * @returns {CredentialFile}
  */
 function read(name) {
+  const file = path.join(MACHINE_CREDENTIAL_DIR, name)
+
+  let stat
   try {
-    return fs.readFileSync(path.join(MACHINE_CREDENTIAL_DIR, name))
-  } catch {
-    return null
+    stat = fs.statSync(file)
+  } catch (e) {
+    return fail(name, file, e)
+  }
+
+  const cached = files.get(name)
+  if (cached?.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached
+  }
+
+  try {
+    const entry = {
+      content: fs.readFileSync(file),
+      error: null,
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    }
+    files.set(name, entry)
+    return entry
+  } catch (e) {
+    return fail(name, file, e)
   }
 }
 
+/**
+ * A file that exists but will not open degrades this add-on quietly, so say so
+ * once. No mtime is recorded, so the next call retries rather than caching the
+ * failure.
+ */
+function fail(name, file, e) {
+  const absent = e?.code === 'ENOENT'
+
+  if (!absent && !reported.has(file)) {
+    reported.add(file)
+    console.error(
+      `⚠️  Cannot read the mounted credential at ${file}: ${e?.code || e?.message}`,
+    )
+  }
+
+  const entry = { content: null, error: absent ? null : e }
+  files.set(name, entry)
+
+  return entry
+}
+
 export function machineToken() {
-  return read(TOKEN_FILE)?.toString('utf8').trim() || ''
+  return read(TOKEN_FILE).content?.toString('utf8').trim() || ''
 }
 
 /** Portainer's own TLS certificate, or null where it serves plain HTTP. */
 export function portainerCA() {
-  return read(CA_FILE)
+  return read(CA_FILE).content
 }
 
 export function hasMachineCredential() {
   return machineToken() !== ''
+}
+
+/**
+ * Whether the token exists but will not open. Distinct from having no token:
+ * the add-on holds a credential it cannot present, which reads as healthy to
+ * anything that only asks whether one is mounted.
+ */
+export function machineTokenUnreadable() {
+  return read(TOKEN_FILE).error !== null
+}
+
+/**
+ * Whether Portainer's certificate is present but unopenable, as opposed to
+ * never published. Callers must not fall back to an unverified connection on
+ * this.
+ */
+export function portainerCAUnreadable() {
+  return read(CA_FILE).error !== null
 }

--- a/server/routes/setup.js
+++ b/server/routes/setup.js
@@ -3,7 +3,8 @@
  * what it cannot do — reloading this process's settings, importing a hand-set
  * key from the pod's own environment, and clearing a key-mismatch warning.
  *
- * No Portainer-Run credential: writes forward the calling admin's own token.
+ * Writes forward the calling admin's own token even where this add-on has a
+ * credential: adopting a key is a deliberate act, and Portainer records who.
  */
 
 import { CORS } from '../lib/cors.js'

--- a/server/routes/setup.js
+++ b/server/routes/setup.js
@@ -10,8 +10,8 @@
 import { CORS } from '../lib/cors.js'
 import {
   encryptionKey,
-  ensureHydrated,
-  hydrate,
+  encryptionKeyIsLocal,
+  refetch,
   isConfigured,
   settingsStatus,
 } from '../settings.js'
@@ -52,7 +52,7 @@ export async function handleSetup(req, res, pathname) {
       isAdmin: caller.isAdmin,
       settings: settingsStatus(),
       // A key in our environment can be imported so it outlives this process.
-      canAdoptLocalKey: isConfigured() && !settingsStatus().hydrated,
+      canAdoptLocalKey: encryptionKeyIsLocal(),
       keyStatus: continuity.status,
       affectedConnections: continuity.affectedConnections,
       gatewayPskStale: continuity.gatewayPskStale,
@@ -69,7 +69,7 @@ export async function handleSetup(req, res, pathname) {
   // Called by the setup screen after saving: settings are memory-only, so this
   // is what makes them live.
   if (pathname === '/api/setup/reload' && req.method === 'POST') {
-    const ok = await hydrate(caller.token)
+    const ok = await refetch(caller.token)
     json(res, ok ? 200 : 502, {
       ok,
       setupRequired: !isConfigured(),

--- a/server/server.js
+++ b/server/server.js
@@ -35,14 +35,17 @@ function onError(e) {
 // production), which forwards plain HTTP, so this server never speaks HTTPS.
 const httpServer = http.createServer(handleRequest)
 
-// Warn on a changed key before listen, so it heads the pod log.
-const continuity = reportKeyContinuity()
 warnUnverified(resolvePortainerTarget()?.isHttps)
 
 httpServer.listen(PORT, async () => {
   // With a credential mounted this comes up configured, no user behind it.
   // Listening first keeps the probes served while Portainer is being reached.
   await ensureHydrated()
+
+  // Only meaningful once the key is in hand: judged before the fetch, an
+  // instance that keeps its key in Portainer reports every restart as a
+  // dropped one.
+  const continuity = reportKeyContinuity()
 
   console.log(
     isConfigured()

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,13 @@
 import http from 'node:http'
 import { CACHE_FILE, PORT, PORTAINER_URL } from './config.js'
-import { aiProvider, baseDomain, isConfigured } from './settings.js'
+import {
+  aiProvider,
+  baseDomain,
+  credentialHealth,
+  ensureHydrated,
+  isConfigured,
+} from './settings.js'
+import { hasMachineCredential } from './machine-credential.js'
 import { handleRequest } from './handler.js'
 import { reportKeyContinuity } from './lib/key-continuity.js'
 
@@ -30,7 +37,11 @@ const httpServer = http.createServer(handleRequest)
 // Warn on a changed key before listen, so it heads the pod log.
 const continuity = reportKeyContinuity()
 
-httpServer.listen(PORT, () => {
+httpServer.listen(PORT, async () => {
+  // Comes up configured with no user behind it. Listening first keeps the
+  // probes served while Portainer is being reached.
+  if (hasMachineCredential()) await ensureHydrated()
+
   console.log(
     isConfigured()
       ? '\n✅  Portainer-Run started'
@@ -46,12 +57,15 @@ httpServer.listen(PORT, () => {
     `    Domain:    ${baseDomain() || '(not set — NodePort fallback)'}`,
   )
   console.log(
+    // An add-on that read Portainer and found nothing stored is new.
     `    Config:    ${
-      !isConfigured()
-        ? 'awaiting an admin to run setup (fetched from Portainer on demand)'
-        : continuity.status === 'mismatch'
-          ? 'encryption key changed ⚠️'
-          : 'ready ✓'
+      credentialHealth() !== 'ok'
+        ? 'could not be read from Portainer ⚠️'
+        : !isConfigured()
+          ? 'awaiting an admin to run setup'
+          : continuity.status === 'mismatch'
+            ? 'encryption key changed ⚠️'
+            : 'ready ✓'
     }\n`,
   )
 })

--- a/server/server.js
+++ b/server/server.js
@@ -7,9 +7,10 @@ import {
   ensureHydrated,
   isConfigured,
 } from './settings.js'
-import { hasMachineCredential } from './machine-credential.js'
 import { handleRequest } from './handler.js'
 import { reportKeyContinuity } from './lib/key-continuity.js'
+import { warnUnverified } from './lib/portainer-tls.js'
+import { resolvePortainerTarget } from './resolve-portainer.js'
 
 function onError(e) {
   const err = e
@@ -36,11 +37,12 @@ const httpServer = http.createServer(handleRequest)
 
 // Warn on a changed key before listen, so it heads the pod log.
 const continuity = reportKeyContinuity()
+warnUnverified(resolvePortainerTarget()?.isHttps)
 
 httpServer.listen(PORT, async () => {
-  // Comes up configured with no user behind it. Listening first keeps the
-  // probes served while Portainer is being reached.
-  if (hasMachineCredential()) await ensureHydrated()
+  // With a credential mounted this comes up configured, no user behind it.
+  // Listening first keeps the probes served while Portainer is being reached.
+  await ensureHydrated()
 
   console.log(
     isConfigured()

--- a/server/settings.js
+++ b/server/settings.js
@@ -10,7 +10,12 @@
 
 import { portainerRequest } from './lib/portainer-api.js'
 import { resolvePortainerTarget } from './resolve-portainer.js'
-import { hasMachineCredential, machineToken } from './machine-credential.js'
+import {
+  hasMachineCredential,
+  machineToken,
+  machineTokenUnreadable,
+  portainerCAUnreadable,
+} from './machine-credential.js'
 
 const ADDON_ID = 'portainer-run'
 
@@ -47,8 +52,10 @@ let hydratedAt = null
 let lastError = null
 /** @type {Promise<boolean> | null} */
 let inFlight = null
-/** Set when this add-on's own credential was refused or could not be trusted. */
-let credentialRejected = false
+/** Why this add-on's own credential last failed: null, 'rejected' or 'certificate'. */
+let credentialFailure = null
+/** Whether the last successful fetch carried an ENCRYPTION_KEY of Portainer's own. */
+let keyCameFromPortainer = false
 
 /** @param {string} key */
 export function getSetting(key) {
@@ -114,52 +121,57 @@ export function settingsStatus() {
  * @returns {'ok' | 'credential-invalid' | 'settings-unavailable'}
  */
 export function credentialHealth() {
+  // A file that exists and will not open is a credential the add-on holds and
+  // cannot present, so ask that before asking whether it works.
+  if (credentialUnreadable()) return 'credential-invalid'
+
   // A credential since removed has nothing left to repair.
   if (!hasMachineCredential()) return 'ok'
 
-  if (credentialRejected) return 'credential-invalid'
+  if (credentialFailure) return 'credential-invalid'
   // Env-seeded settings skip hydration, so never hydrating is not a fault.
   if (hydratedAt === null && !isConfigured()) return 'settings-unavailable'
 
   return 'ok'
 }
 
-/** Shortest gap between retries, so a fast prober cannot hammer Portainer. */
-const CREDENTIAL_RETRY_INTERVAL = 15_000
-let lastCredentialRetry = 0
-
-/**
- * Re-read the credential and try again after it failed.
- *
- * Hydration is otherwise retried only by inbound API traffic, so an idle add-on
- * stays broken after a repair. Portainer's health probe calls this, making the
- * thing that reports the fault the thing that clears it. Not awaited, so the
- * probe stays fast.
- */
-export function retryFailedHydration() {
-  if (credentialHealth() === 'ok') return
-  if (Date.now() - lastCredentialRetry < CREDENTIAL_RETRY_INTERVAL) return
-
-  // Stamped before the await so concurrent probes cannot stack up retries.
-  lastCredentialRetry = Date.now()
-  hydrate().catch(() => {})
+function credentialUnreadable() {
+  return machineTokenUnreadable() || portainerCAUnreadable()
 }
 
 /**
- * Whether reaching Portainer failed on its certificate — Node reports these on
- * `code` with no status attached. The chain failures are the ones that do not
- * carry CERT in the name.
+ * Shortest gap between opportunistic hydrations, so neither a fast prober nor
+ * unauthenticated traffic turns into a Portainer round trip per request.
  */
-function isCertificateError(e) {
-  const code = e?.code
-  if (typeof code !== 'string') return false
+const HYDRATE_RETRY_INTERVAL = 15_000
+let lastHydrateAttempt = 0
 
-  return (
-    code.includes('CERT') ||
-    code.startsWith('ERR_TLS') ||
-    code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
-    code === 'SELF_SIGNED_CERT_IN_CHAIN'
-  )
+/**
+ * Which half of the credential failed. A refused token and an untrusted
+ * certificate need the same repair, so /healthz reports which one it was
+ * without echoing the upstream message to an unauthenticated caller.
+ *
+ * @returns {'rejected' | 'certificate' | null}
+ */
+function failureCause(e) {
+  if (e?.status === 401 || e?.status === 403) return 'rejected'
+
+  const code = e?.code
+  if (
+    typeof code === 'string' &&
+    (code.includes('CERT') || code.startsWith('ERR_TLS'))
+  ) {
+    return 'certificate'
+  }
+
+  return null
+}
+
+/** @returns {'rejected' | 'certificate' | 'unreadable' | undefined} */
+export function credentialFault() {
+  if (credentialUnreadable()) return 'unreadable'
+
+  return credentialFailure ?? undefined
 }
 
 /**
@@ -169,7 +181,7 @@ function isCertificateError(e) {
  * @param {string} [adminToken] Only used where no credential is mounted
  * @returns {Promise<boolean>} whether the fetch succeeded
  */
-export async function hydrate(adminToken) {
+async function hydrate(adminToken) {
   const target = resolvePortainerTarget()
   if (!target) {
     lastError = 'No Portainer target available'
@@ -177,21 +189,31 @@ export async function hydrate(adminToken) {
   }
 
   const machine = machineToken()
-  const token = machine || adminToken
+  // Prefer the add-on's own credential, but let a caller's token through once
+  // that credential has been refused, so a broken one can be recovered without
+  // uninstalling.
+  const asAdmin =
+    Boolean(adminToken) && (!machine || credentialFailure !== null)
+  const token = asAdmin ? adminToken : machine
   if (!token) {
     lastError =
       'No add-on credential is mounted and no admin token was supplied'
     return false
   }
 
-  const path = machine ? MACHINE_CONFIG_PATH : ADMIN_CONFIG_PATH
+  const path = asAdmin ? ADMIN_CONFIG_PATH : MACHINE_CONFIG_PATH
 
   try {
     const body = await portainerRequest(target, token, 'GET', path)
-    const entries = Array.isArray(body?.entries) ? body.entries : []
+    // A 200 carrying something else is not an add-on with no settings yet:
+    // treating it as one would invite an administrator to generate a second
+    // ENCRYPTION_KEY over data the first one encrypted.
+    if (!Array.isArray(body?.entries)) {
+      throw new Error('Portainer returned no configuration entry list')
+    }
 
     const fetched = {}
-    for (const entry of entries) {
+    for (const entry of body.entries) {
       if (!entry?.key || typeof entry.value !== 'string') continue
       if (!KNOWN_KEYS.includes(entry.key)) continue
       fetched[entry.key] = entry.value
@@ -200,30 +222,85 @@ export async function hydrate(adminToken) {
     values = { ...seeded, ...fetched }
     hydratedAt = Date.now()
     lastError = null
-    credentialRejected = false
+    keyCameFromPortainer = 'ENCRYPTION_KEY' in fetched
+    // A borrowed admin token says nothing about this add-on's credential, so a
+    // fetch that worked around a broken one leaves the fault standing.
+    if (!asAdmin) credentialFailure = null
     return true
   } catch (e) {
     lastError = e instanceof Error ? e.message : String(e)
-    // A borrowed admin token says nothing about this add-on's credential. A
-    // refusal and an untrusted certificate share one remedy: republish both.
-    credentialRejected =
-      Boolean(machine) &&
-      (e?.status === 401 || e?.status === 403 || isCertificateError(e))
+    // Only a recognised cause replaces a recorded one. A 500 says nothing about
+    // the credential, and letting it clear a known rejection would report the
+    // add-on healthy with nothing left to retry.
+    if (!asAdmin) credentialFailure = failureCause(e) ?? credentialFailure
     return false
   }
 }
 
 /**
- * Hydrate unless configured, collapsing concurrent callers onto one request.
+ * Collapse concurrent callers onto one request.
  * @param {string} [adminToken] Only needed where no credential is mounted.
  */
-export function ensureHydrated(adminToken) {
-  if (isConfigured()) return Promise.resolve(true)
+function hydrateOnce(adminToken) {
   if (inFlight) return inFlight
 
+  lastHydrateAttempt = Date.now()
   inFlight = hydrate(adminToken).finally(() => {
     inFlight = null
   })
 
   return inFlight
+}
+
+/**
+ * Fetch again, for an administrator who has just saved.
+ *
+ * A hydrate already running was started before that save, so joining it would
+ * report a pre-save snapshot as a successful reload. Waiting for it to settle
+ * also keeps the two from assigning the settings out of order.
+ *
+ * @param {string} [adminToken] Only needed where no credential is mounted.
+ */
+export function refetch(adminToken) {
+  const settled = inFlight ? inFlight.catch(() => {}) : Promise.resolve()
+
+  return settled.then(() => hydrateOnce(adminToken))
+}
+
+/**
+ * Fetch unless there is nothing left to fetch for.
+ *
+ * The one opportunistic entry point: startup, unidentified inbound traffic and
+ * Portainer's health probe all arrive here, so none can pick a variant that
+ * skips the throttle or the in-flight collapse. An administrator's explicit
+ * reload goes through refetch instead.
+ *
+ * Throttled because the caller may be traffic that has not been identified yet:
+ * an unconfigured instance must not turn every request into a round trip.
+ *
+ * @param {string} [adminToken] Only needed where no credential is mounted, or
+ * where the mounted one has been refused.
+ * @returns {Promise<boolean>}
+ */
+export function ensureHydrated(adminToken) {
+  // Settings can be live from an env seed or an earlier fetch while the
+  // credential is not, so being configured is not on its own a reason to stop.
+  if (isConfigured() && credentialHealth() === 'ok')
+    return Promise.resolve(true)
+  if (!machineToken() && !adminToken) return Promise.resolve(false)
+  if (inFlight) return inFlight
+  if (Date.now() - lastHydrateAttempt < HYDRATE_RETRY_INTERVAL) {
+    return Promise.resolve(false)
+  }
+
+  return hydrateOnce(adminToken)
+}
+
+/**
+ * Whether the key this process holds came from its own environment rather than
+ * Portainer. That is the one that can be adopted: storing it in Portainer is
+ * what makes it outlive this pod.
+ */
+export function encryptionKeyIsLocal() {
+  return isConfigured() && !keyCameFromPortainer
 }

--- a/server/settings.js
+++ b/server/settings.js
@@ -1,16 +1,21 @@
 /**
  * Configuration fetched from Portainer and held in memory only, so a restart
- * starts unconfigured until something hydrates it again.
+ * refetches rather than starting from disk.
  *
- * Portainer's endpoints are admin-only and Portainer-Run has no credential, so
- * a fetch borrows an admin caller's token — from the setup screen's reload, or
- * opportunistically in handler.js. Env vars seed values for local dev.
+ * A fetch authenticates as the add-on where Portainer has issued it a
+ * credential, which is what lets it run at startup with no user behind it, and
+ * otherwise borrows an admin caller's token so the two sides can be released
+ * independently. Env vars seed values for local dev.
  */
 
 import { portainerRequest } from './lib/portainer-api.js'
 import { resolvePortainerTarget } from './resolve-portainer.js'
+import { hasMachineCredential, machineToken } from './machine-credential.js'
 
 const ADDON_ID = 'portainer-run'
+
+const MACHINE_CONFIG_PATH = '/api/addon-store/v1/config'
+const ADMIN_CONFIG_PATH = `/api/addons/${ADDON_ID}/config`
 
 export const MIN_ENCRYPTION_KEY_LENGTH = 32
 
@@ -42,6 +47,8 @@ let hydratedAt = null
 let lastError = null
 /** @type {Promise<boolean> | null} */
 let inFlight = null
+/** Set when this add-on's own credential was refused or could not be trusted. */
+let credentialRejected = false
 
 /** @param {string} key */
 export function getSetting(key) {
@@ -91,29 +98,96 @@ export function settingsStatus() {
     hydratedAt,
     configured: isConfigured(),
     lastError,
+    hasCredential: hasMachineCredential(),
+    credential: credentialHealth(),
   }
+}
+
+/**
+ * How this add-on's own credential is faring, as /healthz reports it.
+ *
+ * 'credential-invalid' is what Portainer offers a Repair for, so a credential
+ * that has merely never worked yet reports separately — that is usually a
+ * Portainer which was not up, and Repair would send an administrator after a
+ * fault that is not there.
+ *
+ * @returns {'ok' | 'credential-invalid' | 'settings-unavailable'}
+ */
+export function credentialHealth() {
+  // A credential since removed has nothing left to repair.
+  if (!hasMachineCredential()) return 'ok'
+
+  if (credentialRejected) return 'credential-invalid'
+  // Env-seeded settings skip hydration, so never hydrating is not a fault.
+  if (hydratedAt === null && !isConfigured()) return 'settings-unavailable'
+
+  return 'ok'
+}
+
+/** Shortest gap between retries, so a fast prober cannot hammer Portainer. */
+const CREDENTIAL_RETRY_INTERVAL = 15_000
+let lastCredentialRetry = 0
+
+/**
+ * Re-read the credential and try again after it failed.
+ *
+ * Hydration is otherwise retried only by inbound API traffic, so an idle add-on
+ * stays broken after a repair. Portainer's health probe calls this, making the
+ * thing that reports the fault the thing that clears it. Not awaited, so the
+ * probe stays fast.
+ */
+export function retryFailedHydration() {
+  if (credentialHealth() === 'ok') return
+  if (Date.now() - lastCredentialRetry < CREDENTIAL_RETRY_INTERVAL) return
+
+  // Stamped before the await so concurrent probes cannot stack up retries.
+  lastCredentialRetry = Date.now()
+  hydrate().catch(() => {})
+}
+
+/**
+ * Whether reaching Portainer failed on its certificate — Node reports these on
+ * `code` with no status attached. The chain failures are the ones that do not
+ * carry CERT in the name.
+ */
+function isCertificateError(e) {
+  const code = e?.code
+  if (typeof code !== 'string') return false
+
+  return (
+    code.includes('CERT') ||
+    code.startsWith('ERR_TLS') ||
+    code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
+    code === 'SELF_SIGNED_CERT_IN_CHAIN'
+  )
 }
 
 /**
  * Replace the in-memory copy from Portainer. Env seeds stay underneath, so a
  * setting Portainer lacks falls back rather than disappearing.
- * @param {string} token An administrator's Portainer token
+ *
+ * @param {string} [adminToken] Only used where no credential is mounted
  * @returns {Promise<boolean>} whether the fetch succeeded
  */
-export async function hydrate(token) {
+export async function hydrate(adminToken) {
   const target = resolvePortainerTarget()
-  if (!target || !token) {
-    lastError = 'No Portainer target or token available'
+  if (!target) {
+    lastError = 'No Portainer target available'
     return false
   }
 
+  const machine = machineToken()
+  const token = machine || adminToken
+  if (!token) {
+    lastError =
+      'No add-on credential is mounted and no admin token was supplied'
+    return false
+  }
+
+  const path = machine ? MACHINE_CONFIG_PATH : ADMIN_CONFIG_PATH
+
   try {
-    const body = await portainerRequest(
-      target,
-      token,
-      'GET',
-      `/api/addons/${ADDON_ID}/config`,
-    )
+    const body = await portainerRequest(target, token, 'GET', path)
     const entries = Array.isArray(body?.entries) ? body.entries : []
 
     const fetched = {}
@@ -126,19 +200,28 @@ export async function hydrate(token) {
     values = { ...seeded, ...fetched }
     hydratedAt = Date.now()
     lastError = null
+    credentialRejected = false
     return true
   } catch (e) {
     lastError = e instanceof Error ? e.message : String(e)
+    // A borrowed admin token says nothing about this add-on's credential. A
+    // refusal and an untrusted certificate share one remedy: republish both.
+    credentialRejected =
+      Boolean(machine) &&
+      (e?.status === 401 || e?.status === 403 || isCertificateError(e))
     return false
   }
 }
 
-/** Hydrate unless configured, collapsing concurrent callers onto one request. */
-export function ensureHydrated(token) {
+/**
+ * Hydrate unless configured, collapsing concurrent callers onto one request.
+ * @param {string} [adminToken] Only needed where no credential is mounted.
+ */
+export function ensureHydrated(adminToken) {
   if (isConfigured()) return Promise.resolve(true)
   if (inFlight) return inFlight
 
-  inFlight = hydrate(token).finally(() => {
+  inFlight = hydrate(adminToken).finally(() => {
     inFlight = null
   })
 


### PR DESCRIPTION
Portainer now issues this add-on its own credential, mounted as a Secret holding
a token and the certificate serving Portainer's TLS. Reading settings no longer
needs a user behind it, so the add-on comes up configured at startup instead of
waiting for an administrator to visit it. Where none is mounted — a Portainer
that has not issued one, or local development — it still borrows an admin
caller's token, so the two sides can be released independently. It falls back to
that token again once its own credential has been refused, so a broken one can
be recovered without uninstalling.

It is mounted rather than passed through env because the kubelet refreshes a
mounted Secret in place, which is what lets a repaired credential reach a
running pod without a restart.

Calls are verified against the published certificate by identity rather than by
chain. OpenSSL will not treat a leaf as a trust anchor, so a certificate file
holding just the serving certificate can never verify as a chain — and that is
the ordinary shape, one cluster serving a self-signed certificate with no SANs.
A peer presenting the published certificate byte for byte is accepted on that
alone; anything else must verify against the published file normally, which
admits a renewal only where that file carries the issuer. The pin ignores
validity dates: they bound a chain this does not rest on, and an expired
published certificate has no republishing of its own, so enforcing them would
leave a repair handing back the same certificate with no way out. TLS session
resumption is off, since a resumed handshake carries no certificate to check.

Every outbound client shares those terms and a timeout — 10s for a read, 120s
for a write, which can be Portainer cloning a repository and applying manifests
inline — including the one deciding whether a caller is an administrator.

/healthz reports how the credential is faring, apart from /config so Kubernetes
probes are unaffected: 401 tells Portainer to offer a repair, where a probe
would restart the pod and fix nothing. A refusal is not the only way a
credential fails — an untrusted certificate fails the handshake with no status
code — so one that has never worked reports 503, usually a Portainer that was
not up yet. The response names which half failed without echoing the upstream
message to an unauthenticated caller. Portainer's own probe drives the retry.
