### PR TITLE
fix(settings): carry the encryption key across the upgrade [R8S-1253]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,20 @@ jobs:
           submodules: recursive
           token: ${{ steps.fetch-token.outputs.token }}
 
+      # Node 24 to match the image, and for glob support in the test script.
+      - name: '[preparation] set up node'
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24
+
       - name: '[validation] check server syntax'
         run: node --check server/server.js
+
+      - name: '[preparation] install helm'
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: '[validation] run tests'
+        run: npm test
 
       - name: '[preparation] capture git commit'
         id: git-info

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -6,6 +6,15 @@ metadata:
     {{- include "portainer-run.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  # maxSurge 0 because the cache PVC is ReadWriteOnce: a second pod on another
+  # node cannot mount it. Not Recreate — the API server defaults rollingUpdate
+  # into existing installs, Helm's three-way merge keeps it, and Recreate
+  # rejects the pair.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   # Prevents slow installs when something is failing
   progressDeadlineSeconds: 180
   selector:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,37 @@
+{{- /*
+  Carries an ENCRYPTION_KEY set as a Helm value in 1.3.0 across the upgrade to
+  the release that reads settings from Portainer.
+
+  Values fall back to the live Secret, not to a values default: add-on upgrades
+  run with ResetValues, which blanks a value-sourced default.
+
+  The keep policy lets a later release drop this template without pruning the
+  Secret from an install that has not adopted its key. It also survives an
+  uninstall, so a reinstall inherits the old key; delete it by hand to reset.
+*/}}
+{{- $supplied := .Values.secret | default dict }}
+{{- $live := (lookup "v1" "Secret" .Release.Namespace "portainer-run-secret").data | default dict }}
+{{- $carried := dict }}
+{{- range $key := list "ENCRYPTION_KEY" "ANTHROPIC_API_KEY" "OPENAI_API_KEY" }}
+{{- $value := get $supplied $key | default (get $live $key | default "" | b64dec) }}
+{{- if $value }}
+{{- $_ := set $carried $key $value }}
+{{- end }}
+{{- end }}
+{{- if $carried }}
+apiVersion: v1
+kind: Secret
+metadata:
+  # Not templated: the deployment reads this name, and the lookup must match
+  # what the previous release created.
+  name: portainer-run-secret
+  labels:
+    {{- include "portainer-run.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  {{- range $key, $value := $carried }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,3 +12,8 @@ storageClass: '' # Optional. StorageClass for the session-cache PVC. Empty uses 
 # Empty by design: Portainer-Run reads its settings from Portainer at runtime.
 # Rendered generically, so `--set configMap.<KEY>=...` needs no template change.
 configMap: {}
+
+# Empty by design, as above. A key already in the Secret is carried across
+# upgrades and adopted into Portainer on boot — see templates/secret.yaml.
+# Accepts ENCRYPTION_KEY, ANTHROPIC_API_KEY and OPENAI_API_KEY.
+secret: {}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "bun run --cwd client dev",
     "start": "node server/server.js",
+    "test": "node --test \"server/**/*.test.js\" \"test/**/*.test.js\"",
     "build": "bun run --cwd client build",
     "preview": "bun run --cwd client preview",
     "docker:run": "bash scripts/docker-run.sh",

--- a/server/lib/key-continuity.js
+++ b/server/lib/key-continuity.js
@@ -8,6 +8,7 @@ import crypto from 'node:crypto'
 import db from '../db/db.js'
 import { encryptionKey, isConfigured } from '../settings.js'
 import { classifyKeyState } from './key-state.js'
+import { heldKeyDecryptsStoredRow } from '../models/connection.js'
 
 const FINGERPRINT_KV_KEY = 'encryption_key_fingerprint'
 
@@ -62,6 +63,7 @@ function compute() {
     current,
     encryptedRows: encryptedRowCount(),
     gatewayPsk: hasGatewayPsk(),
+    decryptsStoredRow: configured ? heldKeyDecryptsStoredRow() : null,
   })
 
   if (rebaseline) writeStored(current)
@@ -110,10 +112,10 @@ export function reportKeyContinuity() {
           '\n    This is NOT a fresh install. The key was most likely dropped by a\n' +
           '    release applied with an empty value. Restore it in Portainer —\n' +
           '    generating a new one will permanently orphan the data above.\n'
-      : '\n❌  ENCRYPTION_KEY has changed since this instance last started.\n' +
+      : '\n❌  ENCRYPTION_KEY does not match the data on this volume.\n' +
           parts.join('\n') +
-          '\n    Restore the previous key in Portainer to recover, or acknowledge the\n' +
-          '    change from Portainer-Run settings to start over with the new one.\n',
+          '\n    Restore the key that encrypted it in Portainer to recover, or\n' +
+          '    acknowledge the change from Portainer-Run settings to start over.\n',
   )
   return c
 }

--- a/server/lib/key-continuity.js
+++ b/server/lib/key-continuity.js
@@ -7,6 +7,7 @@
 import crypto from 'node:crypto'
 import db from '../db/db.js'
 import { encryptionKey, isConfigured } from '../settings.js'
+import { classifyKeyState } from './key-state.js'
 
 const FINGERPRINT_KV_KEY = 'encryption_key_fingerprint'
 
@@ -43,13 +44,7 @@ function hasGatewayPsk() {
   )
 }
 
-/**
- * @typedef {object} KeyContinuity
- * @property {'unconfigured'|'ok'|'mismatch'|'lost'} status
- *   `lost` — no key but encrypted data exists. Never a first run.
- * @property {number} affectedConnections  Git targets that will no longer decrypt.
- * @property {boolean} gatewayPskStale     Whether the registered gateway PSK is orphaned.
- */
+/** @typedef {import('./key-state.js').KeyContinuity} KeyContinuity */
 
 /** @type {KeyContinuity | null} */
 let memo = null
@@ -58,41 +53,20 @@ let memoKey = null
 
 /** @returns {KeyContinuity} */
 function compute() {
-  if (!isConfigured()) {
-    // A recorded fingerprint means the key went away rather than never being
-    // set. Mistaking that for a first run invites generating a replacement.
-    const stored = readStored()
-    const affectedConnections = stored ? encryptedRowCount() : 0
-    const gatewayPskStale = stored ? hasGatewayPsk() : false
-    if (stored && (affectedConnections > 0 || gatewayPskStale)) {
-      return { status: 'lost', affectedConnections, gatewayPskStale }
-    }
-    return {
-      status: 'unconfigured',
-      affectedConnections: 0,
-      gatewayPskStale: false,
-    }
-  }
+  const configured = isConfigured()
+  const current = configured ? fingerprint(encryptionKey()) : null
 
-  const current = fingerprint(encryptionKey())
-  const stored = readStored()
+  const { rebaseline, ...verdict } = classifyKeyState({
+    configured,
+    stored: readStored(),
+    current,
+    encryptedRows: encryptedRowCount(),
+    gatewayPsk: hasGatewayPsk(),
+  })
 
-  if (!stored || stored === current) {
-    // First boot on this volume, or the expected steady state.
-    if (!stored) writeStored(current)
-    return { status: 'ok', affectedConnections: 0, gatewayPskStale: false }
-  }
+  if (rebaseline) writeStored(current)
 
-  const affectedConnections = encryptedRowCount()
-  const gatewayPskStale = hasGatewayPsk()
-
-  // Nothing encrypted behind it, so the change costs nothing. Adopt silently.
-  if (affectedConnections === 0 && !gatewayPskStale) {
-    writeStored(current)
-    return { status: 'ok', affectedConnections: 0, gatewayPskStale: false }
-  }
-
-  return { status: 'mismatch', affectedConnections, gatewayPskStale }
+  return verdict
 }
 
 /** Verdict for the key currently held. Recomputed when that key changes. */

--- a/server/lib/key-state.js
+++ b/server/lib/key-state.js
@@ -1,0 +1,81 @@
+/**
+ * The encryption key verdict, decided from a snapshot of the volume.
+ *
+ * No database access: key-continuity.js reads the snapshot and passes it in.
+ */
+
+/**
+ * @typedef {object} KeyContinuity
+ * @property {'unconfigured'|'ok'|'mismatch'|'lost'} status
+ *   `lost` — no key but encrypted data exists. Never a first run.
+ * @property {number} affectedConnections  Git targets that will no longer decrypt.
+ * @property {boolean} gatewayPskStale     Whether the registered gateway PSK is orphaned.
+ */
+
+/**
+ * @typedef {object} KeyState
+ * @property {boolean} configured    Whether a usable key is held.
+ * @property {string | null} stored  Fingerprint recorded on this volume.
+ * @property {string | null} current Fingerprint of the key held now.
+ * @property {number} encryptedRows
+ * @property {boolean} gatewayPsk
+ */
+
+/**
+ * @param {KeyState} state
+ * @returns {KeyContinuity & {rebaseline: boolean}} `rebaseline` asks the caller
+ * to record the current key as the new baseline.
+ */
+export function classifyKeyState({
+  configured,
+  stored,
+  current,
+  encryptedRows,
+  gatewayPsk,
+}) {
+  if (!configured) {
+    // Rows, not the fingerprint: 1.3.0 never recorded one, so gating on it
+    // reads the upgrade that loses the key as a first run.
+    if (encryptedRows > 0 || gatewayPsk) {
+      return {
+        status: 'lost',
+        affectedConnections: encryptedRows,
+        gatewayPskStale: gatewayPsk,
+        rebaseline: false,
+      }
+    }
+    return {
+      status: 'unconfigured',
+      affectedConnections: 0,
+      gatewayPskStale: false,
+      rebaseline: false,
+    }
+  }
+
+  // First boot on this volume, or the expected steady state.
+  if (!stored || stored === current) {
+    return {
+      status: 'ok',
+      affectedConnections: 0,
+      gatewayPskStale: false,
+      rebaseline: !stored,
+    }
+  }
+
+  // Nothing encrypted behind it, so the change costs nothing. Adopt silently.
+  if (encryptedRows === 0 && !gatewayPsk) {
+    return {
+      status: 'ok',
+      affectedConnections: 0,
+      gatewayPskStale: false,
+      rebaseline: true,
+    }
+  }
+
+  return {
+    status: 'mismatch',
+    affectedConnections: encryptedRows,
+    gatewayPskStale: gatewayPsk,
+    rebaseline: false,
+  }
+}

--- a/server/lib/key-state.js
+++ b/server/lib/key-state.js
@@ -19,6 +19,8 @@
  * @property {string | null} current Fingerprint of the key held now.
  * @property {number} encryptedRows
  * @property {boolean} gatewayPsk
+ * @property {boolean | null} decryptsStoredRow Whether the key held opens an
+ *   existing row, or null where there are none to try.
  */
 
 /**
@@ -32,6 +34,7 @@ export function classifyKeyState({
   current,
   encryptedRows,
   gatewayPsk,
+  decryptsStoredRow,
 }) {
   if (!configured) {
     // Rows, not the fingerprint: 1.3.0 never recorded one, so gating on it
@@ -52,13 +55,33 @@ export function classifyKeyState({
     }
   }
 
-  // First boot on this volume, or the expected steady state.
-  if (!stored || stored === current) {
+  if (!stored) {
+    // No fingerprint to compare, so authentication is the only check left: a
+    // key that cannot open an existing row is not the one that wrote it.
+    if (decryptsStoredRow === false) {
+      return {
+        status: 'mismatch',
+        affectedConnections: encryptedRows,
+        gatewayPskStale: gatewayPsk,
+        rebaseline: false,
+      }
+    }
+
+    // First boot on this volume.
     return {
       status: 'ok',
       affectedConnections: 0,
       gatewayPskStale: false,
-      rebaseline: !stored,
+      rebaseline: true,
+    }
+  }
+
+  if (stored === current) {
+    return {
+      status: 'ok',
+      affectedConnections: 0,
+      gatewayPskStale: false,
+      rebaseline: false,
     }
   }
 

--- a/server/lib/key-state.test.js
+++ b/server/lib/key-state.test.js
@@ -1,0 +1,103 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { classifyKeyState } from './key-state.js'
+
+const KEY_A = 'fingerprint-of-key-a'
+const KEY_B = 'fingerprint-of-key-b'
+
+/** @param {Partial<Parameters<typeof classifyKeyState>[0]>} overrides */
+function state(overrides) {
+  return classifyKeyState({
+    configured: false,
+    stored: null,
+    current: null,
+    encryptedRows: 0,
+    gatewayPsk: false,
+    ...overrides,
+  })
+}
+
+test('a first run is unconfigured, and records nothing', () => {
+  assert.deepEqual(state({}), {
+    status: 'unconfigured',
+    affectedConnections: 0,
+    gatewayPskStale: false,
+    rebaseline: false,
+  })
+})
+
+// R8S-1253
+test('a lost key is detected from the rows alone, with no fingerprint', () => {
+  assert.deepEqual(state({ encryptedRows: 3 }), {
+    status: 'lost',
+    affectedConnections: 3,
+    gatewayPskStale: false,
+    rebaseline: false,
+  })
+})
+
+test('a lost key is detected from an orphaned gateway PSK', () => {
+  assert.deepEqual(state({ gatewayPsk: true }), {
+    status: 'lost',
+    affectedConnections: 0,
+    gatewayPskStale: true,
+    rebaseline: false,
+  })
+})
+
+test('a fingerprint with nothing encrypted behind it is still a first run', () => {
+  assert.equal(state({ stored: KEY_A }).status, 'unconfigured')
+})
+
+test('first boot on a volume records the key as the baseline', () => {
+  assert.deepEqual(state({ configured: true, current: KEY_A }), {
+    status: 'ok',
+    affectedConnections: 0,
+    gatewayPskStale: false,
+    rebaseline: true,
+  })
+})
+
+test('the steady state records nothing', () => {
+  assert.deepEqual(state({ configured: true, stored: KEY_A, current: KEY_A }), {
+    status: 'ok',
+    affectedConnections: 0,
+    gatewayPskStale: false,
+    rebaseline: false,
+  })
+})
+
+test('a changed key with nothing behind it is adopted silently', () => {
+  assert.deepEqual(state({ configured: true, stored: KEY_A, current: KEY_B }), {
+    status: 'ok',
+    affectedConnections: 0,
+    gatewayPskStale: false,
+    rebaseline: true,
+  })
+})
+
+test('a changed key with data behind it is a mismatch, and is not adopted', () => {
+  assert.deepEqual(
+    state({
+      configured: true,
+      stored: KEY_A,
+      current: KEY_B,
+      encryptedRows: 2,
+      gatewayPsk: true,
+    }),
+    {
+      status: 'mismatch',
+      affectedConnections: 2,
+      gatewayPskStale: true,
+      rebaseline: false,
+    },
+  )
+})
+
+test('a changed key is a mismatch on a stale PSK alone', () => {
+  assert.equal(
+    state({ configured: true, stored: KEY_A, current: KEY_B, gatewayPsk: true })
+      .status,
+    'mismatch',
+  )
+})

--- a/server/lib/key-state.test.js
+++ b/server/lib/key-state.test.js
@@ -13,6 +13,7 @@ function state(overrides) {
     current: null,
     encryptedRows: 0,
     gatewayPsk: false,
+    decryptsStoredRow: null,
     ...overrides,
   })
 }
@@ -56,6 +57,42 @@ test('first boot on a volume records the key as the baseline', () => {
     gatewayPskStale: false,
     rebaseline: true,
   })
+})
+
+// R8S-1253
+test('a key that cannot open an existing row is a mismatch, not a first boot', () => {
+  assert.deepEqual(
+    state({
+      configured: true,
+      current: KEY_A,
+      encryptedRows: 2,
+      gatewayPsk: true,
+      decryptsStoredRow: false,
+    }),
+    {
+      status: 'mismatch',
+      affectedConnections: 2,
+      gatewayPskStale: true,
+      rebaseline: false,
+    },
+  )
+})
+
+test('a key that opens an existing row becomes the baseline', () => {
+  assert.deepEqual(
+    state({
+      configured: true,
+      current: KEY_A,
+      encryptedRows: 2,
+      decryptsStoredRow: true,
+    }),
+    {
+      status: 'ok',
+      affectedConnections: 0,
+      gatewayPskStale: false,
+      rebaseline: true,
+    },
+  )
 })
 
 test('the steady state records nothing', () => {

--- a/server/models/connection.js
+++ b/server/models/connection.js
@@ -37,6 +37,21 @@ function decrypt(stored) {
   return JSON.parse(decrypted.toString('utf8'))
 }
 
+/** Whether the key now held decrypts a stored row. Null when there are none. */
+export function heldKeyDecryptsStoredRow() {
+  const row = db
+    .prepare('SELECT encrypted_payload FROM connections LIMIT 1')
+    .get()
+  if (!row) return null
+
+  try {
+    decrypt(row.encrypted_payload)
+    return true
+  } catch {
+    return false
+  }
+}
+
 function rowToConn(conn) {
   return {
     id: conn.id,

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 import http from 'node:http'
 import { CACHE_FILE, PORT, PORTAINER_URL } from './config.js'
 import {
+  adoptEnvKey,
   aiProvider,
   baseDomain,
   credentialHealth,
@@ -41,6 +42,9 @@ httpServer.listen(PORT, async () => {
   // With a credential mounted this comes up configured, no user behind it.
   // Listening first keeps the probes served while Portainer is being reached.
   await ensureHydrated()
+
+  // Not awaited: nothing below reads the result, and it can retry for minutes.
+  void adoptEnvKey().catch(() => {})
 
   // Only meaningful once the key is in hand: judged before the fetch, an
   // instance that keeps its key in Portainer reports every restart as a

--- a/server/server.js
+++ b/server/server.js
@@ -32,6 +32,19 @@ function onError(e) {
   process.exit(1)
 }
 
+const ADOPT_RETRY_INTERVAL = 15_000
+
+/**
+ * Keep offering the key to Portainer until its home is decided.
+ *
+ * The credential is mounted optional and Portainer may still be starting, so a
+ * first attempt can fail with nothing wrong.
+ */
+async function adoptWhenPossible() {
+  if ((await adoptEnvKey().catch(() => 'retry')) !== 'retry') return
+  setTimeout(adoptWhenPossible, ADOPT_RETRY_INTERVAL).unref()
+}
+
 // TLS terminates at the proxy in front of us (the Portainer addon gateway in
 // production), which forwards plain HTTP, so this server never speaks HTTPS.
 const httpServer = http.createServer(handleRequest)
@@ -44,7 +57,7 @@ httpServer.listen(PORT, async () => {
   await ensureHydrated()
 
   // Not awaited: nothing below reads the result, and it can retry for minutes.
-  void adoptEnvKey().catch(() => {})
+  void adoptWhenPossible()
 
   // Only meaningful once the key is in hand: judged before the fetch, an
   // instance that keeps its key in Portainer reports every restart as a

--- a/server/settings.js
+++ b/server/settings.js
@@ -54,8 +54,10 @@ let lastError = null
 let inFlight = null
 /** Why this add-on's own credential last failed: null, 'rejected' or 'certificate'. */
 let credentialFailure = null
-/** Whether the last successful fetch carried an ENCRYPTION_KEY of Portainer's own. */
+/** Whether Portainer holds this add-on's ENCRYPTION_KEY. */
 let keyCameFromPortainer = false
+/** One attempt per process: a restart retries it, a loop would not help. */
+let adoptionAttempted = false
 
 /** @param {string} key */
 export function getSetting(key) {
@@ -303,4 +305,44 @@ export function ensureHydrated(adminToken) {
  */
 export function encryptionKeyIsLocal() {
   return isConfigured() && !keyCameFromPortainer
+}
+
+/**
+ * Hand an environment-seeded ENCRYPTION_KEY to Portainer, so it outlives this pod.
+ *
+ * Unattended: by the time an administrator could press Adopt in setup, the
+ * Secret that a later release drops is already gone.
+ *
+ * @returns {Promise<boolean>} whether Portainer now holds the key
+ */
+export async function adoptEnvKey() {
+  if (adoptionAttempted || !encryptionKeyIsLocal()) return false
+  adoptionAttempted = true
+
+  const target = resolvePortainerTarget()
+  const token = machineToken()
+  if (!target || !token) return false
+
+  // Ask first: a stale chart seed must not overwrite a key Portainer holds, and
+  // a configured instance never fetches on its own.
+  if (!(await hydrateOnce())) return false
+  if (keyCameFromPortainer) return false
+
+  try {
+    await portainerRequest(
+      target,
+      token,
+      'PATCH',
+      `${MACHINE_CONFIG_PATH}/ENCRYPTION_KEY`,
+      JSON.stringify({ value: encryptionKey(), sensitive: true }),
+    )
+  } catch (e) {
+    // Never record the key, or a message that might carry it.
+    lastError = e instanceof Error ? e.message : String(e)
+    return false
+  }
+
+  keyCameFromPortainer = true
+
+  return true
 }

--- a/server/settings.js
+++ b/server/settings.js
@@ -56,8 +56,14 @@ let inFlight = null
 let credentialFailure = null
 /** Whether Portainer holds this add-on's ENCRYPTION_KEY. */
 let keyCameFromPortainer = false
-/** One attempt per process: a restart retries it, a loop would not help. */
-let adoptionAttempted = false
+/**
+ * @typedef {'adopted'|'settled'|'retry'} AdoptionOutcome
+ *   `settled` — Portainer holds a key, or there is no local one to hand over.
+ *   `retry` — the attempt could not be made yet, which says nothing either way.
+ */
+
+/** Latched once the key's home is decided. */
+let adoptionSettled = false
 
 /** @param {string} key */
 export function getSetting(key) {
@@ -313,20 +319,22 @@ export function encryptionKeyIsLocal() {
  * Unattended: by the time an administrator could press Adopt in setup, the
  * Secret that a later release drops is already gone.
  *
- * @returns {Promise<boolean>} whether Portainer now holds the key
+ * @returns {Promise<AdoptionOutcome>}
  */
 export async function adoptEnvKey() {
-  if (adoptionAttempted || !encryptionKeyIsLocal()) return false
-  adoptionAttempted = true
+  if (adoptionSettled || !encryptionKeyIsLocal()) return 'settled'
 
   const target = resolvePortainerTarget()
   const token = machineToken()
-  if (!target || !token) return false
+  if (!target || !token) return 'retry'
 
   // Ask first: a stale chart seed must not overwrite a key Portainer holds, and
   // a configured instance never fetches on its own.
-  if (!(await hydrateOnce())) return false
-  if (keyCameFromPortainer) return false
+  if (!(await hydrateOnce())) return 'retry'
+  if (keyCameFromPortainer) {
+    adoptionSettled = true
+    return 'settled'
+  }
 
   try {
     await portainerRequest(
@@ -339,10 +347,11 @@ export async function adoptEnvKey() {
   } catch (e) {
     // Never record the key, or a message that might carry it.
     lastError = e instanceof Error ? e.message : String(e)
-    return false
+    return 'retry'
   }
 
   keyCameFromPortainer = true
+  adoptionSettled = true
 
-  return true
+  return 'adopted'
 }

--- a/server/settings.js
+++ b/server/settings.js
@@ -336,6 +336,8 @@ export async function adoptEnvKey() {
     return 'settled'
   }
 
+  // A key stored between the read-back and here is overwritten on purpose: the
+  // rows on this volume are encrypted with the one being handed over.
   try {
     await portainerRequest(
       target,

--- a/test/chart.test.js
+++ b/test/chart.test.js
@@ -1,0 +1,77 @@
+/**
+ * Chart rendering.
+ *
+ * `lookup` returns empty without a cluster, so only the no-live-Secret half of
+ * secret.yaml is covered here. Carrying a key across an upgrade needs a real
+ * release: package/server-ee/dev/incluster/scenario-encryption-key.sh.
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const CHART = fileURLToPath(new URL('../chart', import.meta.url))
+
+const hasHelm = spawnSync('helm', ['version']).status === 0
+
+/** @param {string[]} args */
+function render(...args) {
+  return execFileSync('helm', ['template', 'portainer-run', CHART, ...args], {
+    encoding: 'utf8',
+  })
+}
+
+describe('chart', { skip: hasHelm ? false : 'helm is not installed' }, () => {
+  test('a supplied key is rendered into the Secret', () => {
+    const out = render('--set', 'secret.ENCRYPTION_KEY=abc123')
+
+    assert.match(out, /kind: Secret/)
+    assert.match(out, /name: portainer-run-secret/)
+    assert.match(
+      out,
+      new RegExp(
+        `ENCRYPTION_KEY: "${Buffer.from('abc123').toString('base64')}"`,
+      ),
+    )
+  })
+
+  // Without it, a later release that drops this template prunes the Secret.
+  test('the Secret is annotated to survive a release that stops rendering it', () => {
+    const out = render('--set', 'secret.ENCRYPTION_KEY=abc123')
+
+    assert.match(out, /helm\.sh\/resource-policy: keep/)
+  })
+
+  test('no Secret is rendered when there is nothing to put in it', () => {
+    const out = render()
+
+    assert.doesNotMatch(out, /kind: Secret/)
+  })
+
+  test('the other supported keys are carried too', () => {
+    const out = render('--set', 'secret.ANTHROPIC_API_KEY=sk-ant')
+
+    assert.match(
+      out,
+      new RegExp(
+        `ANTHROPIC_API_KEY: "${Buffer.from('sk-ant').toString('base64')}"`,
+      ),
+    )
+    assert.doesNotMatch(out, /ENCRYPTION_KEY/)
+  })
+
+  test('an unsupported key is not carried', () => {
+    const out = render('--set', 'secret.SOME_OTHER_KEY=nope')
+
+    assert.doesNotMatch(out, /SOME_OTHER_KEY/)
+  })
+
+  // A fresh render cannot show why this is maxSurge and not Recreate — see the
+  // template.
+  test('the deployment replaces its pod rather than surging a second one', () => {
+    const out = render()
+
+    assert.match(out, /maxSurge: 0/)
+  })
+})


### PR DESCRIPTION
Installs that set `ENCRYPTION_KEY` as a Helm value lose it when they upgrade to the release that drops `chart/templates/secret.yaml`. The rows it encrypts sit on the cache PVC, which survives, so they are left unreadable.

Restore `secret.yaml`, defaulting each value from a `lookup` of the live Secret. Add-on upgrades run with `ResetValues`, so a values default reverts to empty and takes the key with it; the cluster is the only source that survives. `helm.sh/resource-policy: keep` lets a later release drop the template without pruning the Secret from an install that has not adopted its key.

Adopt an environment-seeded key into Portainer on boot, retrying until Portainer can accept it, and read back what Portainer holds first so a stale seed cannot overwrite it.

Three further changes:

- Decide the `lost` state from the encrypted rows rather than a recorded fingerprint. 1.3.0 volumes have none, so the warning could not fire on the upgrade this fixes, and the setup screen offered to generate a replacement over recoverable data.
- Try decrypting a row before recording a key as the baseline. With no fingerprint to compare, a key arriving from the store was accepted on trust; where it was not the key that encrypted the rows, they were lost silently.
- `maxSurge: 0`, so the upgrade does not stall with two pods contending for one ReadWriteOnce PVC. Recreate cannot be used: the API server defaults `rollingUpdate` into existing installs, Helm's three-way merge keeps it, and Recreate rejects the pair.

## Follow-up

`secret.yaml` stays in 1.3.1 — dropping it is what leaves nothing to adopt. A release after this one can remove the template and the `secretRef`. `GET /api/addons/portainer-run/config` shows whether an install has migrated.

## Testing

`npm test` covers the verdict table and what the chart renders. Carrying a key across a live upgrade needs a cluster, so that is not in the suite.

Verified on Portainer 2.45.0 EE on k0s, installing 1.3.0 from a Portainer registry and upgrading through the add-on API:

- The key is carried into the new Secret, adopted into Portainer within seconds, and the connection still decrypts.
- Deleting the Secret and restarting leaves the add-on working, so the key no longer depends on the chart.
- Upgrading the add-on before the server: the install stays healthy on the chart's key, and adoption completes in the same pod once the server can accept it.
- A stored key that did not encrypt the rows reports `mismatch` rather than a first run, and records no baseline.
- Only one pod runs at a time during the rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
