### PR TITLE
fix(mcp): use unprivileged nginx image for static sites [FR-1209]

### DIFF
--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -61,7 +61,7 @@ const SERVER_INSTRUCTIONS = [
   '',
   'Static sites: if the app is plain HTML/CSS/JS with no server-side logic, deploy it as a static site — send only the static files (index.html, css, js, assets) and set runtime to "nginx". Do NOT scaffold a Node/Express (or any) server to serve static files; adding a package.json would make it deploy as a Node app instead of nginx.',
   '',
-  'Port: deploy_app has no port parameter. The service port is inferred from the detected runtime (Node 3000, Python 8000, php/nginx 80, Ruby 9292). Make the app listen on that runtime default and bind 0.0.0.0. If the app must use a non-standard port, warn the user that the MCP deploy may expose the wrong port and the app could be unreachable.',
+  'Port: deploy_app has no port parameter. The service port is inferred from the detected runtime (Node 3000, Python 8000, php 80, nginx 8080, Ruby 9292). Make the app listen on that runtime default and bind 0.0.0.0. If the app must use a non-standard port, warn the user that the MCP deploy may expose the wrong port and the app could be unreachable.',
   '',
   'Always show a summary of the chosen settings and get explicit confirmation before calling deploy_app.',
   '',
@@ -404,19 +404,23 @@ async function toolListIngressClasses(req, args) {
 }
 
 // ---------------------------------------------------------------------------
-// Runtime detection (server-side mirror of client/src/components/VibeDeploy.jsx)
+// Runtime detection (server-side mirror of client/src/pages/deploy/runtimes.ts)
 //
 // The browser UI fills runtime/runtimeImage/startCmd/workDir/port before calling
 // the deploy backend. The MCP path has no UI, so without this it would always
 // deploy a bare node:22-slim image with no start command — which crashloops.
-// Keep this in sync with the RUNTIMES table in VibeDeploy.jsx.
+// Keep this in sync with the RUNTIMES table in client/src/pages/deploy/runtimes.ts.
 // ---------------------------------------------------------------------------
 
 const NGINX_RUNTIME = {
   id: 'nginx',
-  image: 'nginx:alpine',
+  // Unprivileged NGINX: runs as UID 101, listens on 8080, and moves its PID and
+  // temp paths to /tmp, so it needs no Linux capabilities at startup. Required
+  // because all pods drop ALL capabilities under our pod security baseline (#39).
+  // Note: a custom nginx.conf must include `pid /tmp/nginx.pid`.
+  image: 'nginxinc/nginx-unprivileged:alpine',
   defaultCmd: () => "nginx -g 'daemon off;'",
-  port: 80,
+  port: 8080,
   workDir: '/usr/share/nginx/html',
 }
 


### PR DESCRIPTION
Ticket: **FR-1209**

## What changed

The MCP path's server-side runtime table specified `nginx:alpine` on port 80. The browser deploy path had already moved to `nginxinc/nginx-unprivileged:alpine` on 8080. This brings the MCP mirror in line.

## Why

Every pod gets `capabilities: { drop: ['ALL'] }` from `CONTAINER_SECURITY_CONTEXT` in `server/routes/vibe.js`, and `nginx` is not in `RUNTIMES_NEEDING_CAPS` — only `php` is, as a deliberate scoped exception (#39). So an MCP-deployed static site was asking for an image that cannot start under our own security baseline:

- it fails on the `chown` of its cache dirs, since `CHOWN` is dropped — this is the one that shows up in the logs
- the port 80 bind would fail too, because dropping ALL takes `NET_BIND_SERVICE` away from root as well

To be clear about the direction of the bug: this was **not** a privileged container or an escalation. It's the opposite — an image that needs privileges deployed onto a baseline that denies them. The blast radius is a broken deploy, not a security hole. Deploys through the browser UI were never affected.

## Also in this diff

Two stale things in the same block, both plausible contributors:

- The header comment pointed at `client/src/components/VibeDeploy.jsx`, which no longer exists. The table now lives in `client/src/pages/deploy/runtimes.ts`. A "keep this in sync with X" comment naming a deleted file is a good way for X to drift.
- The model-facing tool instruction in `SERVER_INSTRUCTIONS` advertised `php/nginx 80`. That string is what the LLM reads when deciding which port the app it writes should bind, so a wrong value there reproduces the same unreachable-app failure by a different route. Now reads `php 80, nginx 8080`.

## Notes for the reviewer

- **Not verified by an actual deploy.** The failure mode above is derived from reading the code and the existing comment at `vibe.js:275`, not from watching a crashloop. If someone has a cluster handy, an MCP `deploy_app` with `runtime: "nginx"` before/after would confirm it.
- I diffed every field (`id` / `image` / `port` / `workDir`) of both runtime tables. node, python, php and ruby all agree; nginx was the only drift.
- **Nothing guards this.** No test asserts the two tables agree, which is why this sat unnoticed. A test parsing the image and port out of `runtimes.ts` and asserting against `RUNTIMES` in `mcp.js` would catch the next one. Happy to add it here or as a follow-up — say which you'd prefer.
- `npm test` passes (11/11; the chart test skips locally, helm not installed). Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
