### PR TITLE
feat(applications): rebuild the list on DataTable, add breadcrumb app switcher

### DIFF
--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -27,11 +27,13 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: '[preparation] download image artifact'
+      # One single-arch OCI tarball per arch, built on native runners in ci.
+      - name: '[preparation] download image artifacts'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: pr-image
+          pattern: pr-image-*
           path: /tmp
+          merge-multiple: true
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -69,7 +71,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: '[execution] push image to registry'
-        # Extract the pre-built OCI tarball and push via imagetools create.
+        # Extract the two pre-built single-arch OCI tarballs and assemble them
+        # into one multi-arch tag via imagetools create.
         # Specify the tag explicitly in the oci-layout reference — Docker 28+ /
         # BuildKit v0.29+ no longer resolves an untagged oci-layout reference
         # and defaults to :latest, which won't exist in the layout.
@@ -79,11 +82,14 @@ jobs:
         # The fork's code was compiled in the sandboxed ci workflow — we never
         # execute it here.
         run: |
-          mkdir /tmp/image-oci
-          tar -xf /tmp/image.tar -C /tmp/image-oci
+          for arch in amd64 arm64; do
+            mkdir "/tmp/image-oci-${arch}"
+            tar -xf "/tmp/image-${arch}.tar" -C "/tmp/image-oci-${arch}"
+          done
           docker buildx imagetools create \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.value }} \
-            "oci-layout:///tmp/image-oci:${{ steps.tag.outputs.value }}"
+            "oci-layout:///tmp/image-oci-amd64:${{ steps.tag.outputs.value }}" \
+            "oci-layout:///tmp/image-oci-arm64:${{ steps.tag.outputs.value }}"
 
       - name: '[execution] post PR comment'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,8 @@ jobs:
             echo "value=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
-  build:
+  validate:
     runs-on: ubuntu-latest
-    needs: tag
     steps:
       # Exchange the org's GitHub App credentials for a short-lived, narrowly
       # scoped installation token so checkout can pull the private design-system
@@ -69,6 +68,41 @@ jobs:
       - name: '[validation] run tests'
         run: npm test
 
+  # One job per target arch, built in parallel on native runners (org-level
+  # ubuntu-latest-arm64 runner group for arm64) — no QEMU. Node's V8 JIT
+  # crashes with SIGILL under QEMU user-mode emulation, which is why the
+  # previous single-job multi-arch build hung and timed out. Same pattern as
+  # portainer-idp's build-images job.
+  build:
+    name: build (linux/${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    needs: [tag, validate]
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-latest-arm64
+    steps:
+      # Short-lived token — design-system is a separate private repo the
+      # default token can't see.
+      - name: '[preparation] fetch GitHub App token'
+        id: fetch-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.PORTAINER_BOT_ID }}
+          private-key: ${{ secrets.PORTAINER_BOT_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: portainer-run,design-system
+          permission-contents: read
+
+      - name: '[preparation] checkout the current branch'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ steps.fetch-token.outputs.token }}
+
       - name: '[preparation] capture git commit'
         id: git-info
         run: echo "sha=$(git log -1 --format=%h)" >> "$GITHUB_OUTPUT"
@@ -77,13 +111,13 @@ jobs:
         id: build-date
         run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
-      - name: '[preparation] set up QEMU'
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
       - name: '[preparation] set up Docker Buildx'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: '[execution] build multi-arch image and export as OCI tarball'
+      # --- pull_request path: fork-safe, no registry credentials ---
+      # Each leg exports a single-arch OCI tarball artifact; the privileged
+      # ci-publish workflow assembles them into one multi-arch tag and pushes.
+      - name: '[execution] build single-arch image and export as OCI tarball'
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
@@ -92,35 +126,40 @@ jobs:
           context: .
           push: false
           load: false
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           build-args: |
             PORTAINER_RUN_VERSION=${{ needs.tag.outputs.value }}
             GIT_COMMIT=${{ steps.git-info.outputs.sha }}
             BUILD_DATE=${{ steps.build-date.outputs.date }}
           tags: ${{ env.IMAGE_NAME }}:${{ needs.tag.outputs.value }}
-          outputs: type=oci,dest=/tmp/image.tar
-
-      - name: '[execution] save image tag metadata'
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "${{ needs.tag.outputs.value }}" > /tmp/image-tag.txt
+          outputs: type=oci,dest=/tmp/image-${{ matrix.arch }}.tar
 
       - name: '[execution] upload image artifact'
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: pr-image
-          path: /tmp/image.tar
+          name: pr-image-${{ matrix.arch }}
+          path: /tmp/image-${{ matrix.arch }}.tar
           retention-days: 1
 
+      # The tag artifact only needs to exist once — the amd64 leg writes it.
+      - name: '[execution] save image tag metadata'
+        if: github.event_name == 'pull_request' && matrix.arch == 'amd64'
+        run: |
+          echo "${{ needs.tag.outputs.value }}" > /tmp/image-tag.txt
+
       - name: '[execution] upload image tag artifact'
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.arch == 'amd64'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-image-tag
           path: /tmp/image-tag.txt
           retention-days: 1
 
+      # --- push path: trusted code, push by digest ---
+      # Pushes by digest only (no tag); the manifest job below assembles the
+      # per-arch digests into one multi-arch tag.
+      # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
       - name: '[preparation] log in to registry'
         if: github.event_name != 'pull_request'
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -128,19 +167,63 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: '[execution] build and push multi-arch image'
+      - name: '[execution] build and push single-arch image by digest'
         if: github.event_name != 'pull_request'
+        id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
-          # Use the local checkout (with the submodule already fetched) as the
-          # build context, so BuildKit doesn't re-clone the repo over SSH.
           context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           build-args: |
             PORTAINER_RUN_VERSION=${{ needs.tag.outputs.value }}
             GIT_COMMIT=${{ steps.git-info.outputs.sha }}
             BUILD_DATE=${{ steps.build-date.outputs.date }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.tag.outputs.value }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           sbom: true
           provenance: mode=max
+
+      - name: '[post] export digest'
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: '[post] upload digest artifact'
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  # Assembles the two per-arch digests pushed above into one multi-arch tag.
+  # push events only — PR images are assembled by the ci-publish workflow,
+  # which is the only place PR-path registry credentials live.
+  manifest:
+    runs-on: ubuntu-latest
+    needs: [tag, build]
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: '[preparation] download digest artifacts'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: '[preparation] set up Docker Buildx'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: '[preparation] log in to registry'
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: '[execution] create and push multi-arch manifest'
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.tag.outputs.value }} \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo, useState } from 'react'
+import { forwardRef, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { Box, Home, MessageSquare, type LucideIcon } from 'lucide-react'
 
@@ -106,19 +106,28 @@ const ShellLink = forwardRef<
   return <Link ref={ref} to={to ?? '#'} {...rest} />
 })
 
-function useShellBreadcrumbs(): BreadcrumbItem[] {
+function useShellBreadcrumbs(appSwitcher?: ReactNode): BreadcrumbItem[] {
   const { pathname } = useLocation()
   const items = getBreadcrumbItems(pathname)
+  const isAppRoute = appFromPath(pathname) !== null
   return [
     {
       label: '',
       icon: <Home size={14} />,
       linkProps: { to: ROUTES.dashboard },
     },
-    ...items.map((item: { label: string; to?: string; current?: boolean }) => ({
-      label: item.label,
-      linkProps: item.to ? { to: item.to } : undefined,
-    })),
+    ...items.map(
+      (item: { label: string; to?: string; current?: boolean }, i: number) => ({
+        label: item.label,
+        linkProps: item.to ? { to: item.to } : undefined,
+        // On an app route getBreadcrumbItems always emits
+        // [Applications, <app name>, …], so index 1 is the app crumb — the
+        // one the switcher replaces. Matching on the label instead would
+        // misfire on an app named after a tab.
+        switcher:
+          isAppRoute && i === 1 && appSwitcher ? appSwitcher : undefined,
+      }),
+    ),
   ]
 }
 
@@ -260,7 +269,71 @@ export function AppLayout() {
       .flatMap((s) => s.items)
       .find((item) => pathname.startsWith(item.path))?.id ?? ''
 
-  const breadcrumbs = useShellBreadcrumbs()
+  /* Every app the user can reach, as switcher items. Labels are the bare app
+     name: nearly every user can deploy into a single environment, so the
+     environment adds noise to every row to disambiguate a case they will not
+     hit. Ids stay the full env/ns/name key, so apps that do share a name
+     across environments remain distinct targets. */
+  const appSwitcherItems = useMemo(() => {
+    const visibleEnvIds = new Set(
+      environments
+        .filter((e) => !disabledEnvs?.[String(e.Id)])
+        .map((e) => String(e.Id)),
+    )
+    return deployments
+      .filter((d) => visibleEnvIds.has(String(d._envId)))
+      .map((d) => ({
+        envId: String(d._envId),
+        namespace: d.metadata?.namespace ?? '',
+        name: d.metadata?.name ?? '',
+      }))
+      .filter((r) => r.name)
+      .map((r) => ({ id: favoriteKey(r), label: r.name, target: r }))
+      .sort((a, b) =>
+        a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }),
+      )
+  }, [environments, disabledEnvs, deployments])
+
+  /* Keep the tab when switching apps — going from one app's Logs to another's
+     Logs is the point of switching here. */
+  const currentTab = useMemo(() => {
+    const segs = pathname.split('/').filter(Boolean)
+    return segs[0] === 'applications' && segs.length >= 5
+      ? decodeURIComponent(segs[4])
+      : 'overview'
+  }, [pathname])
+
+  /* Only once the current app is actually in the list: ApplicationSwitcher
+     falls back to items[0] when `selected` matches nothing, which would show
+     the wrong app (or crash on an empty list) while the cache is still
+     loading. Until then the crumb stays plain text. */
+  const currentAppId = currentApp ? favoriteKey(currentApp) : null
+  const appSwitcher =
+    currentAppId &&
+    appSwitcherItems.length > 1 &&
+    appSwitcherItems.some((i) => i.id === currentAppId) ? (
+      <ApplicationSwitcher
+        inlineMode
+        selected={currentAppId}
+        items={appSwitcherItems.map(({ id, label }) => ({ id, label }))}
+        searchable={appSwitcherItems.length > 7}
+        dropdownLabel="Applications"
+        onChange={(id: string) => {
+          const hit = appSwitcherItems.find((i) => i.id === id)
+          if (!hit || id === currentAppId) return
+          navigate(
+            serviceDetailPath(
+              hit.target.envId,
+              hit.target.namespace,
+              hit.target.name,
+              currentTab,
+            ),
+          )
+        }}
+      />
+    ) : undefined
+
+  const breadcrumbs = useShellBreadcrumbs(appSwitcher)
 
   // Other products are separately served apps, not routes in this SPA.
   function handleProductChange(id: string) {
@@ -271,7 +344,6 @@ export function AppLayout() {
 
   return (
     <div
-      className={currentApp ? undefined : 'pr-hide-fav-star'}
       style={{
         display: 'flex',
         width: '100%',
@@ -279,10 +351,6 @@ export function AppLayout() {
         overflow: 'hidden',
       }}
     >
-      {/* Only app detail pages can be favorited. The design-system header always
-          renders its star button, so hide it everywhere else via its stable
-          aria-label rather than patching the read-only submodule. */}
-      <style>{`.pr-hide-fav-star button[aria-label="Add to favourites"],.pr-hide-fav-star button[aria-label="Remove from favourites"]{display:none}`}</style>
       {/* App shell shrinks to make room for the assistant panel instead of being
           covered by it. */}
       <div style={{ flex: 1, minWidth: 0, height: '100vh' }}>
@@ -304,6 +372,7 @@ export function AppLayout() {
             />
           )}
           breadcrumbs={breadcrumbs}
+          showStar={!!currentApp}
           starred={starred}
           onStarToggle={
             currentApp ? () => toggleFavorite(currentApp) : undefined

--- a/client/src/pages/ServicesPage.tsx
+++ b/client/src/pages/ServicesPage.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ArrowUpDown, Check, Eye, ListFilter, RefreshCw } from 'lucide-react'
+import {
+  ArrowUpDown,
+  ArrowUpRight,
+  Check,
+  Eye,
+  ListFilter,
+  RefreshCw,
+} from 'lucide-react'
 
 import { Button } from '@ds/v3-components/Button/Button'
 import { Badge } from '@ds/v3-components/Badge/Badge'
@@ -23,7 +30,6 @@ import {
   useEnvStatusOnDeployments,
   getExtraForApp,
 } from '../hooks/useEnvStatus.js'
-import { age } from '../lib/utils.js'
 import { manualRefresh } from '../services/refreshDeployments.js'
 import type { Deployment } from '../types/k8s'
 
@@ -60,8 +66,6 @@ const HIDEABLE_COLUMNS = [
   { key: 'ns', label: 'Project space' },
   { key: 'status', label: 'Health' },
   { key: 'access', label: 'Access' },
-  { key: 'age', label: 'Deployed' },
-  { key: 'owner', label: 'Deployed by' },
 ]
 
 /* Which columns are hidden is a durable preference, not part of the query —
@@ -157,6 +161,55 @@ function deployedBy(d: Deployment): string {
     d.metadata?.labels?.['io.portainer.kubernetes.application.owner.id'] ||
     '—'
   )
+}
+
+const DEPLOYED_AGO_DATE_CUTOFF_DAYS = 30
+
+/* Written-out relative time ("2 hours" + " ago") for the name subline, split
+   so the caller can emphasize the timeline value without emphasizing "ago".
+   Past the cutoff a written-out age gets stale and hard to place on a
+   timeline, so it falls back to an absolute dd-mm-yyyy date (no suffix)
+   instead. */
+function deployedAgoParts(timestamp: string | undefined): {
+  value: string
+  suffix: string
+} {
+  if (!timestamp) return { value: '—', suffix: '' }
+  const then = new Date(timestamp)
+  const ms = Date.now() - then.getTime()
+  const minutes = Math.floor(ms / 60000)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (days >= DEPLOYED_AGO_DATE_CUTOFF_DAYS) {
+    const dd = String(then.getDate()).padStart(2, '0')
+    const mm = String(then.getMonth() + 1).padStart(2, '0')
+    return { value: `${dd}-${mm}-${then.getFullYear()}`, suffix: '' }
+  }
+  if (days >= 1) {
+    return { value: `${days} day${days === 1 ? '' : 's'}`, suffix: ' ago' }
+  }
+  if (hours >= 1) {
+    return { value: `${hours} hour${hours === 1 ? '' : 's'}`, suffix: ' ago' }
+  }
+  if (minutes >= 1) {
+    return {
+      value: `${minutes} minute${minutes === 1 ? '' : 's'}`,
+      suffix: ' ago',
+    }
+  }
+  return { value: 'just now', suffix: '' }
+}
+
+const BADGE_LABEL_MAX = 40
+
+/* Badge text is capped at a fixed character count rather than left to CSS
+   ellipsis alone — the column is sized for real-world names, and this only
+   kicks in for a pathologically long one. */
+function truncateBadgeLabel(value: string): string {
+  return value.length > BADGE_LABEL_MAX
+    ? `${value.slice(0, BADGE_LABEL_MAX)}…`
+    : value
 }
 
 /* Its own component rather than an inline render, because the per-row
@@ -271,6 +324,7 @@ function AccessCell({
   envStatusClientCache: Record<string, unknown>
 }) {
   const extra = getExtraForApp(envStatusClientCache, d._envId, d.metadata.name)
+  const [hovered, setHovered] = useState(false)
   if (extra.accessUrl) {
     return (
       <a
@@ -279,7 +333,12 @@ function AccessCell({
         rel="noopener noreferrer"
         title={extra.accessLabel || extra.accessUrl}
         onClick={(e) => e.stopPropagation()}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
         style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 2,
           color: 'var(--accent, #2e90fa)',
           fontSize: 12,
           fontWeight: 600,
@@ -287,6 +346,7 @@ function AccessCell({
         }}
       >
         Launch
+        {hovered && <ArrowUpRight size={12} />}
       </a>
     )
   }
@@ -374,20 +434,12 @@ export function ServicesPage() {
         return byName(a, b)
       }
     } else if (listSort === 'age') {
-      // Newest first at 'asc' — the column reads "Deployed", and most-recent
+      // Newest first at 'asc' — "Created" in the Sort menu, and most-recent
       // at the top is the useful default for a deploy list.
       cmp = (a, b) => {
         const at = new Date(a.d.metadata?.creationTimestamp || 0).getTime()
         const bt = new Date(b.d.metadata?.creationTimestamp || 0).getTime()
         return bt - at
-      }
-    } else if (listSort === 'owner') {
-      cmp = (a, b) => {
-        const oa = deployedBy(a.d)
-        const ob = deployedBy(b.d)
-        if (oa !== ob)
-          return oa.localeCompare(ob, undefined, { sensitivity: 'base' })
-        return byName(a, b)
       }
     } else {
       cmp = byName
@@ -475,45 +527,102 @@ export function ServicesPage() {
       key: 'name',
       header: 'Name',
       sortable: true,
-      width: '16%',
+      width: '27%',
       render: ({ d }) => (
-        <span
-          style={{
-            display: 'block',
-            fontWeight: 600,
-            color: 'var(--text)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {d.metadata.name}
-        </span>
+        <div style={{ overflow: 'hidden' }}>
+          <span
+            style={{
+              display: 'block',
+              fontWeight: 600,
+              color: 'var(--text)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {d.metadata.name}
+          </span>
+          {(() => {
+            const ago = deployedAgoParts(d.metadata?.creationTimestamp)
+            return (
+              <span
+                title={`Deployed by ${deployedBy(d)}`}
+                style={{
+                  display: 'block',
+                  marginTop: 2,
+                  fontSize: 12,
+                  color: 'var(--muted)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Deployed by{' '}
+                <span style={{ fontWeight: 600 }}>{deployedBy(d)}</span>
+                {' • '}
+                <span style={{ fontWeight: 600 }}>{ago.value}</span>
+                {ago.suffix}
+              </span>
+            )
+          })()}
+        </div>
       ),
     },
     {
       key: 'env',
       header: 'Environment',
       sortable: true,
-      width: '12%',
-      render: ({ d }) => (
-        <span title={d._envName || '—'}>
-          <Badge tone="neutral" size="sm">
-            {d._envName || '—'}
-          </Badge>
-        </span>
-      ),
+      width: '14%',
+      render: ({ d }) => {
+        const full = d._envName || '—'
+        return (
+          <span title={full} style={{ display: 'block', maxWidth: '100%' }}>
+            <Badge
+              tone="neutral"
+              size="sm"
+              style={{ maxWidth: '100%', overflow: 'hidden' }}
+            >
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {truncateBadgeLabel(full)}
+              </span>
+            </Badge>
+          </span>
+        )
+      },
     },
     {
       key: 'ns',
       header: 'Project space',
       sortable: true,
-      width: '11%',
-      render: ({ d }) => (
-        <Badge tone="neutral" size="sm">
-          {d.metadata.namespace}
-        </Badge>
-      ),
+      width: '22%',
+      render: ({ d }) => {
+        const full = d.metadata.namespace
+        return (
+          <span title={full} style={{ display: 'block', maxWidth: '100%' }}>
+            <Badge
+              tone="neutral"
+              size="sm"
+              style={{ maxWidth: '100%', overflow: 'hidden' }}
+            >
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {truncateBadgeLabel(full)}
+              </span>
+            </Badge>
+          </span>
+        )
+      },
     },
     {
       key: 'status',
@@ -530,38 +639,6 @@ export function ServicesPage() {
       width: '8%',
       render: ({ d }) => (
         <AccessCell d={d} envStatusClientCache={envStatusClientCache} />
-      ),
-    },
-    {
-      key: 'age',
-      header: 'Deployed',
-      sortable: true,
-      width: '10%',
-      render: ({ d }) => (
-        <span style={{ fontSize: 12, color: 'var(--muted)' }}>
-          {age(d.metadata?.creationTimestamp)}
-        </span>
-      ),
-    },
-    {
-      key: 'owner',
-      header: 'Deployed by',
-      sortable: true,
-      width: '14%',
-      render: ({ d }) => (
-        <span
-          title={deployedBy(d)}
-          style={{
-            display: 'block',
-            fontSize: 12,
-            color: 'var(--muted)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {deployedBy(d)}
-        </span>
       ),
     },
     {

--- a/client/src/pages/ServicesPage.tsx
+++ b/client/src/pages/ServicesPage.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { RefreshCw } from 'lucide-react'
+import { ArrowUpDown, Check, Eye, ListFilter, RefreshCw } from 'lucide-react'
 
 import { Button } from '@ds/v3-components/Button/Button'
 import { Badge } from '@ds/v3-components/Badge/Badge'
-import { Skeleton } from '@ds/v3-components/Skeleton/Skeleton'
 import { StatusDot } from '@ds/v3-components/StatusDot/StatusDot'
 import type { StatusTone } from '@ds/v3-components/StatusDot/StatusDot'
 import { StatusBar } from '@ds/v3-components/StatusSummary/StatusSummary'
-import { SortableList } from '@ds/v3-templates/SortableList/SortableList'
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuSection,
+} from '@ds/v3-components/DropdownMenu/DropdownMenu'
+import { DataTableCard } from '@ds/v3-templates/DataTableInCard/DataTableInCard'
+import type { ColumnDef, SortDir } from '@ds/v3-components/DataTable/DataTable'
 import { PageTitle } from '@ds/v3-templates/PageTitle/PageTitle'
 
 import { checkEnvPermissions } from '../lib/envPermissions.js'
@@ -22,6 +27,10 @@ import { age } from '../lib/utils.js'
 import { manualRefresh } from '../services/refreshDeployments.js'
 import type { Deployment } from '../types/k8s'
 
+const PAGE_SIZE = 15
+
+/* Sort values double as DataTable column keys, so a column header click and
+   the Sort menu drive the same state. */
 const SERVICE_LIST_SORT = [
   { value: 'name', label: 'Name' },
   { value: 'env', label: 'Environment' },
@@ -36,18 +45,56 @@ const STATUS_SORT_ORDER = [
   'no_workloads',
 ]
 
-const SVC_STATUS_GROUP: Record<string, { name: string }> = {
-  workloads_down: { name: 'Unavailable' },
-  workloads_degraded: { name: 'Degraded' },
-  workloads_running: { name: 'Running' },
-  no_workloads: { name: 'Switched off' },
-}
-
 const SVC_STATUS_SUBFILTER_EMPTY: Record<string, string> = {
   workloads_down: 'No unavailable applications in this view.',
   workloads_degraded: 'No degraded applications in this view.',
   workloads_running: 'No running applications in this view.',
   no_workloads: 'No applications are scaled to zero in this view.',
+}
+
+/* Columns the View menu can hide. Name and the actions column are always on —
+   a row without its name is unidentifiable, and actions carries the only
+   per-row controls. */
+const HIDEABLE_COLUMNS = [
+  { key: 'env', label: 'Environment' },
+  { key: 'ns', label: 'Project space' },
+  { key: 'status', label: 'Health' },
+  { key: 'access', label: 'Access' },
+  { key: 'age', label: 'Deployed' },
+  { key: 'owner', label: 'Deployed by' },
+]
+
+/* Which columns are hidden is a durable preference, not part of the query —
+   it survives reloads, unlike the sort/filter/page state in `listQuery`.
+   Same storage conventions as lib/favorites.ts. */
+const HIDDEN_COLUMNS_STORAGE_KEY = 'portainer-run.applications.hiddenColumns'
+
+function readHiddenColumns(): string[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(HIDDEN_COLUMNS_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    // Drop anything that is no longer a hideable column, so a renamed or
+    // removed column can't leave a permanently hidden ghost in storage.
+    const valid = new Set(HIDEABLE_COLUMNS.map((c) => c.key))
+    return parsed.filter((k) => typeof k === 'string' && valid.has(k))
+  } catch {
+    return []
+  }
+}
+
+function writeHiddenColumns(next: string[]) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(
+      HIDDEN_COLUMNS_STORAGE_KEY,
+      JSON.stringify(next),
+    )
+  } catch {
+    /* storage full / disabled — the in-memory choice still applies */
+  }
 }
 
 interface ListItem {
@@ -104,60 +151,23 @@ function serviceRowId(d: Deployment): string {
   return `${d._envId}-${d.metadata.namespace}-${d.metadata.name}`
 }
 
-/* Shared grid template: Name | Environment | Project space | Health | Access |
-   Deployed | Deployed by | actions.
-   The header and every row are independent grids. The actions column must be a
-   fixed width (not `auto`) so both resolve the same free space for the `fr`
-   tracks — otherwise the empty header cell and the buttons in each row give the
-   grids different free space and the headers drift out of alignment. */
-const ACTIONS_COL_WIDTH = 120
-const ROW_GRID: React.CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: `minmax(140px, 1.4fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(140px, 1.2fr) minmax(90px, 0.9fr) minmax(70px, 0.6fr) minmax(90px, 0.9fr) ${ACTIONS_COL_WIDTH}px`,
-  alignItems: 'center',
-  gap: 12,
-  padding: '10px 14px',
-}
-
-function ColumnHeaders() {
-  const cell: React.CSSProperties = {
-    fontSize: 10,
-    fontWeight: 600,
-    letterSpacing: '0.07em',
-    textTransform: 'uppercase',
-    color: 'var(--muted)',
-    whiteSpace: 'nowrap',
-  }
+function deployedBy(d: Deployment): string {
   return (
-    <div
-      style={{ ...ROW_GRID, borderBottom: '1px solid var(--border)' }}
-      aria-hidden
-    >
-      <span style={cell}>Name</span>
-      <span style={cell}>Environment</span>
-      <span style={cell}>Project space</span>
-      <span style={cell}>Health</span>
-      <span style={cell}>Access</span>
-      <span style={cell}>Deployed</span>
-      <span style={cell}>Deployed by</span>
-      <span />
-    </div>
+    d.metadata?.labels?.['io.portainer.kubernetes.application.owner'] ||
+    d.metadata?.labels?.['io.portainer.kubernetes.application.owner.id'] ||
+    '—'
   )
 }
 
-interface ServiceRowProps {
-  d: Deployment
-  envStatusClientCache: Record<string, unknown>
-  onOpen: () => void
-  onViewLogs: () => void
-}
-
-function ServiceRow({
+/* Its own component rather than an inline render, because the per-row
+   permission check is a hook — it needs a component that mounts once per row. */
+function RowActions({
   d,
-  envStatusClientCache,
-  onOpen,
   onViewLogs,
-}: ServiceRowProps) {
+}: {
+  d: Deployment
+  onViewLogs: () => void
+}) {
   const token = useAppStore((s) => s.token)
   const setRestartTarget = useAppStore((s) => s.setRestartTarget)
   const envPermissions = useAppStore((s) => s.envPermissions)
@@ -165,7 +175,6 @@ function ServiceRow({
   const permKey = `${d._envId}:${d.metadata.namespace}`
   const perms = envPermissions[permKey] ?? null
 
-  // Fire permission check for this row's env+namespace if not yet cached
   useEffect(() => {
     if (envPermissions[permKey] !== undefined) return
     const envId = d._envId
@@ -176,156 +185,119 @@ function ServiceRow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [permKey])
 
-  const name = d.metadata.name
-  const ns = d.metadata.namespace
-  const envId = d._envId
-  const envName = d._envName || '—'
-  const created = d.metadata?.creationTimestamp
-  const deployedBy =
-    d.metadata?.labels?.['io.portainer.kubernetes.application.owner'] ||
-    d.metadata?.labels?.['io.portainer.kubernetes.application.owner.id'] ||
-    '—'
-  const { tone, label } = rowStatus(d)
-  const extra = getExtraForApp(envStatusClientCache, envId, name)
-
-  const onRestart = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    if (!token) return
-    setRestartTarget({ envId, ns, name })
-  }
-
   return (
     <div
-      role="button"
-      tabIndex={0}
-      style={{
-        ...ROW_GRID,
-        cursor: 'pointer',
-        borderBottom: '1px solid var(--border)',
-      }}
-      data-svc-env={String(envId)}
-      data-svc-name={name}
-      onClick={onOpen}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onOpen()
-        }
-      }}
+      style={{ display: 'flex', gap: 4, justifyContent: 'flex-end' }}
+      onClick={(e) => e.stopPropagation()}
     >
-      <div
-        style={{
-          fontWeight: 600,
-          color: 'var(--text)',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
+      <Button
+        variant="ghost"
+        onClick={onViewLogs}
+        disabled={!perms?.canViewLogs}
+        disabledReason={
+          !perms?.canViewLogs
+            ? 'You do not have permission to view logs in this environment'
+            : undefined
+        }
+      >
+        Logs
+      </Button>
+      <Button
+        variant="ghost"
+        onClick={(e) => {
+          e.stopPropagation()
+          if (!token) return
+          setRestartTarget({
+            envId: d._envId,
+            ns: d.metadata.namespace,
+            name: d.metadata.name,
+          })
         }}
+        disabled={!perms?.canRestart}
+        disabledReason={
+          !perms?.canRestart
+            ? 'You do not have permission to restart workloads in this environment'
+            : undefined
+        }
       >
-        {name}
-      </div>
-      <div title={envName}>
-        <Badge tone="neutral" size="sm">
-          {envName}
-        </Badge>
-      </div>
-      <div>
-        <Badge tone="neutral" size="sm">
-          {ns}
-        </Badge>
-      </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <span
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
-            fontSize: 12,
-            color: 'var(--text)',
-          }}
-        >
-          <StatusDot tone={tone} />
-          {label}
-          {(d.spec?.replicas ?? 0) > 1 && (
-            <span style={{ fontSize: 11, color: 'var(--muted)' }}>
-              {d.status?.readyReplicas || 0}/{d.spec?.replicas}
-            </span>
-          )}
-        </span>
-        {extra.reason ? (
-          <span style={{ fontSize: 11, color: 'var(--muted)' }}>
-            {extra.reason}
-          </span>
-        ) : null}
-      </div>
-      <div onClick={(e) => e.stopPropagation()}>
-        {extra.accessUrl ? (
-          <a
-            href={extra.accessUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            title={extra.accessLabel || extra.accessUrl}
-            style={{
-              color: 'var(--accent, #2e90fa)',
-              fontSize: 12,
-              fontWeight: 600,
-              textDecoration: 'none',
-            }}
-          >
-            Launch
-          </a>
-        ) : extra.accessLabel ? (
-          <span style={{ fontSize: 12, color: 'var(--muted)' }}>
-            {extra.accessLabel}
-          </span>
-        ) : (
-          <span style={{ color: 'var(--muted)' }}>—</span>
-        )}
-      </div>
-      <div style={{ fontSize: 12, color: 'var(--muted)' }}>{age(created)}</div>
-      <div
-        title={deployedBy}
-        style={{
-          fontSize: 12,
-          color: 'var(--muted)',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {deployedBy}
-      </div>
-      <div
-        style={{ display: 'flex', gap: 4, justifyContent: 'flex-end' }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <Button
-          variant="ghost"
-          onClick={onViewLogs}
-          disabled={!perms?.canViewLogs}
-          title={
-            !perms?.canViewLogs
-              ? 'You do not have permission to view logs in this environment'
-              : undefined
-          }
-        >
-          Logs
-        </Button>
-        <Button
-          variant="ghost"
-          onClick={onRestart}
-          disabled={!perms?.canRestart}
-          title={
-            !perms?.canRestart
-              ? 'You do not have permission to restart workloads in this environment'
-              : undefined
-          }
-        >
-          Restart
-        </Button>
-      </div>
+        Restart
+      </Button>
     </div>
   )
+}
+
+function HealthCell({
+  d,
+  envStatusClientCache,
+}: {
+  d: Deployment
+  envStatusClientCache: Record<string, unknown>
+}) {
+  const { tone, label } = rowStatus(d)
+  const extra = getExtraForApp(envStatusClientCache, d._envId, d.metadata.name)
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          fontSize: 12,
+          color: 'var(--text)',
+        }}
+      >
+        <StatusDot tone={tone} />
+        {label}
+        {(d.spec?.replicas ?? 0) > 1 && (
+          <span style={{ fontSize: 11, color: 'var(--muted)' }}>
+            {d.status?.readyReplicas || 0}/{d.spec?.replicas}
+          </span>
+        )}
+      </span>
+      {extra.reason ? (
+        <span style={{ fontSize: 11, color: 'var(--muted)' }}>
+          {extra.reason}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+function AccessCell({
+  d,
+  envStatusClientCache,
+}: {
+  d: Deployment
+  envStatusClientCache: Record<string, unknown>
+}) {
+  const extra = getExtraForApp(envStatusClientCache, d._envId, d.metadata.name)
+  if (extra.accessUrl) {
+    return (
+      <a
+        href={extra.accessUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={extra.accessLabel || extra.accessUrl}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          color: 'var(--accent, #2e90fa)',
+          fontSize: 12,
+          fontWeight: 600,
+          textDecoration: 'none',
+        }}
+      >
+        Launch
+      </a>
+    )
+  }
+  if (extra.accessLabel) {
+    return (
+      <span style={{ fontSize: 12, color: 'var(--muted)' }}>
+        {extra.accessLabel}
+      </span>
+    )
+  }
+  return <span style={{ color: 'var(--muted)' }}>—</span>
 }
 
 export function ServicesPage() {
@@ -339,11 +311,19 @@ export function ServicesPage() {
 
   const [listQuery, setListQuery] = useState<Record<string, string>>({
     sortBy: 'name',
+    sortDir: 'asc',
     filter: '',
     page: '1',
   })
   const listSort = listQuery.sortBy
+  const sortDir = (listQuery.sortDir as SortDir) ?? 'asc'
+  const search = listQuery.filter ?? ''
+  const page = Number(listQuery.page) || 1
+
   const [listSubFilter, setListSubFilter] = useState<string | null>(null)
+  const [envFilter, setEnvFilter] = useState<string | null>(null)
+  const [hiddenColumns, setHiddenColumns] =
+    useState<string[]>(readHiddenColumns)
 
   const deps = useMemo(
     () => visibleDeployments(useAppStore.getState()),
@@ -352,56 +332,98 @@ export function ServicesPage() {
   )
   useEnvStatusOnDeployments(deps, token)
 
-  const listItems: ListItem[] = useMemo(() => {
+  const envNames = useMemo(() => {
+    const names = new Set<string>()
+    for (const d of deps) if (d._envName) names.add(d._envName)
+    return [...names].sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: 'base' }),
+    )
+  }, [deps])
+
+  const sortedItems: ListItem[] = useMemo(() => {
     const base = deps.map((d: Deployment) => ({ id: serviceRowId(d), d }))
-    if (listSort === 'name') {
-      return [...base].sort((a, b) =>
-        a.d.metadata.name.localeCompare(b.d.metadata.name, undefined, {
-          sensitivity: 'base',
-        }),
-      )
-    }
+    const byName = (a: ListItem, b: ListItem) =>
+      a.d.metadata.name.localeCompare(b.d.metadata.name, undefined, {
+        sensitivity: 'base',
+      })
+
+    let cmp: (a: ListItem, b: ListItem) => number
     if (listSort === 'env') {
-      return [...base].sort((a, b) => {
+      cmp = (a, b) => {
         const ea = a.d._envName || ''
         const eb = b.d._envName || ''
         if (ea !== eb)
           return ea.localeCompare(eb, undefined, { sensitivity: 'base' })
-        return a.d.metadata.name.localeCompare(b.d.metadata.name, undefined, {
-          sensitivity: 'base',
-        })
-      })
-    }
-    if (listSort === 'status') {
+        return byName(a, b)
+      }
+    } else if (listSort === 'ns') {
+      cmp = (a, b) => {
+        const na = a.d.metadata.namespace || ''
+        const nb = b.d.metadata.namespace || ''
+        if (na !== nb)
+          return na.localeCompare(nb, undefined, { sensitivity: 'base' })
+        return byName(a, b)
+      }
+    } else if (listSort === 'status') {
       const orderIdx = (x: ListItem) =>
         STATUS_SORT_ORDER.indexOf(primaryServicePartition(x.d))
-      return [...base].sort((a, b) => {
+      cmp = (a, b) => {
         const ia = orderIdx(a)
         const ib = orderIdx(b)
         if (ia !== ib) return ia - ib
-        return a.d.metadata.name.localeCompare(b.d.metadata.name, undefined, {
-          sensitivity: 'base',
-        })
-      })
-    }
-    if (listSort === 'age') {
-      return [...base].sort((a, b) => {
+        return byName(a, b)
+      }
+    } else if (listSort === 'age') {
+      // Newest first at 'asc' — the column reads "Deployed", and most-recent
+      // at the top is the useful default for a deploy list.
+      cmp = (a, b) => {
         const at = new Date(a.d.metadata?.creationTimestamp || 0).getTime()
         const bt = new Date(b.d.metadata?.creationTimestamp || 0).getTime()
-        return bt - at // newest first
-      })
+        return bt - at
+      }
+    } else if (listSort === 'owner') {
+      cmp = (a, b) => {
+        const oa = deployedBy(a.d)
+        const ob = deployedBy(b.d)
+        if (oa !== ob)
+          return oa.localeCompare(ob, undefined, { sensitivity: 'base' })
+        return byName(a, b)
+      }
+    } else {
+      cmp = byName
     }
-    return base
-  }, [deps, listSort])
 
-  /* Sub-filter (from the summary bar) narrows the list to one health
-     partition; only active while sorting by Health, like the old UI. */
+    const out = [...base].sort(cmp)
+    return sortDir === 'desc' ? out.reverse() : out
+  }, [deps, listSort, sortDir])
+
+  /* The health sub-filter (from the summary bar) no longer depends on the
+     sort. SortableList's grouped headers used to supply that context; with
+     DataTable there is no grouping, so the filter has to stand on its own. */
   const visibleItems = useMemo(() => {
-    if (!listSubFilter || listSort !== 'status') return listItems
-    return listItems.filter(
-      (item) => primaryServicePartition(item.d) === listSubFilter,
-    )
-  }, [listItems, listSubFilter, listSort])
+    const q = search.trim().toLowerCase()
+    return sortedItems.filter((item) => {
+      if (listSubFilter && primaryServicePartition(item.d) !== listSubFilter)
+        return false
+      if (envFilter && item.d._envName !== envFilter) return false
+      if (!q) return true
+      const envN = item.d._envName || ''
+      const n = item.d.metadata.name
+      const { label } = rowStatus(item.d)
+      return `${n} ${envN} ${label}`.toLowerCase().includes(q)
+    })
+  }, [sortedItems, listSubFilter, envFilter, search])
+
+  const totalPages = Math.max(1, Math.ceil(visibleItems.length / PAGE_SIZE))
+  const clampedPage = Math.min(page, totalPages)
+  const pageItems = useMemo(
+    () =>
+      visibleItems.slice(
+        (clampedPage - 1) * PAGE_SIZE,
+        clampedPage * PAGE_SIZE,
+      ),
+    [visibleItems, clampedPage],
+  )
 
   const summary = useMemo(() => {
     const total = deps.length
@@ -419,24 +441,251 @@ export function ServicesPage() {
     return { total, running, degraded, unavailable }
   }, [deps])
 
+  function patchQuery(next: Record<string, string>) {
+    setListQuery((q) => ({ ...q, ...next }))
+  }
+
   function selectSubFilter(partition: string | null) {
-    if (partition === null || listSubFilter === partition) {
-      setListSubFilter(null)
-      return
-    }
-    setListQuery((q) => ({ ...q, sortBy: 'status', page: '1' }))
-    setListSubFilter(partition)
+    setListSubFilter(
+      partition === null || listSubFilter === partition ? null : partition,
+    )
+    patchQuery({ page: '1' })
+  }
+
+  function applySort(key: string) {
+    // The same column again flips direction; a new column starts ascending.
+    patchQuery({
+      sortBy: key,
+      sortDir: listSort === key && sortDir === 'asc' ? 'desc' : 'asc',
+      page: '1',
+    })
   }
 
   const initialLoading =
     !cache.deployments.length && cache.fetching && !cache.everLoaded
   const showEmpty = !initialLoading && !deps.length
 
-  const emptyMessage =
-    listSubFilter && listSort === 'status'
-      ? SVC_STATUS_SUBFILTER_EMPTY[listSubFilter] ||
-        'No applications match this filter.'
-      : 'No applications match'
+  const emptyMessage = listSubFilter
+    ? SVC_STATUS_SUBFILTER_EMPTY[listSubFilter] ||
+      'No applications match this filter.'
+    : 'No applications match'
+
+  const allColumns: ColumnDef<ListItem>[] = [
+    {
+      key: 'name',
+      header: 'Name',
+      sortable: true,
+      width: '16%',
+      render: ({ d }) => (
+        <span
+          style={{
+            display: 'block',
+            fontWeight: 600,
+            color: 'var(--text)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {d.metadata.name}
+        </span>
+      ),
+    },
+    {
+      key: 'env',
+      header: 'Environment',
+      sortable: true,
+      width: '12%',
+      render: ({ d }) => (
+        <span title={d._envName || '—'}>
+          <Badge tone="neutral" size="sm">
+            {d._envName || '—'}
+          </Badge>
+        </span>
+      ),
+    },
+    {
+      key: 'ns',
+      header: 'Project space',
+      sortable: true,
+      width: '11%',
+      render: ({ d }) => (
+        <Badge tone="neutral" size="sm">
+          {d.metadata.namespace}
+        </Badge>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Health',
+      sortable: true,
+      width: '15%',
+      render: ({ d }) => (
+        <HealthCell d={d} envStatusClientCache={envStatusClientCache} />
+      ),
+    },
+    {
+      key: 'access',
+      header: 'Access',
+      width: '8%',
+      render: ({ d }) => (
+        <AccessCell d={d} envStatusClientCache={envStatusClientCache} />
+      ),
+    },
+    {
+      key: 'age',
+      header: 'Deployed',
+      sortable: true,
+      width: '10%',
+      render: ({ d }) => (
+        <span style={{ fontSize: 12, color: 'var(--muted)' }}>
+          {age(d.metadata?.creationTimestamp)}
+        </span>
+      ),
+    },
+    {
+      key: 'owner',
+      header: 'Deployed by',
+      sortable: true,
+      width: '14%',
+      render: ({ d }) => (
+        <span
+          title={deployedBy(d)}
+          style={{
+            display: 'block',
+            fontSize: 12,
+            color: 'var(--muted)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {deployedBy(d)}
+        </span>
+      ),
+    },
+    {
+      key: 'actions',
+      header: '',
+      align: 'right',
+      width: '140px',
+      render: ({ d }) => (
+        <RowActions
+          d={d}
+          onViewLogs={() =>
+            navigate(
+              serviceDetailPath(
+                String(d._envId),
+                d.metadata.namespace,
+                d.metadata.name,
+                'logs',
+              ),
+            )
+          }
+        />
+      ),
+    },
+  ]
+
+  const columns = allColumns.filter((c) => !hiddenColumns.includes(c.key))
+
+  const headerActions = (
+    <>
+      <DropdownMenu
+        trigger={
+          <Button variant="secondary" leftSection={<ListFilter size={14} />}>
+            {envFilter ?? 'Environment'}
+          </Button>
+        }
+      >
+        <DropdownMenuItem
+          label="All environments"
+          icon={envFilter === null ? <Check size={14} /> : undefined}
+          onClick={() => {
+            setEnvFilter(null)
+            patchQuery({ page: '1' })
+          }}
+        />
+        {envNames.map((name) => (
+          <DropdownMenuItem
+            key={name}
+            label={name}
+            icon={envFilter === name ? <Check size={14} /> : undefined}
+            onClick={() => {
+              setEnvFilter(name)
+              patchQuery({ page: '1' })
+            }}
+          />
+        ))}
+      </DropdownMenu>
+
+      <span style={{ flex: 1 }} />
+
+      <DropdownMenu
+        align="right"
+        trigger={
+          <Button variant="secondary" leftSection={<Eye size={14} />}>
+            View
+          </Button>
+        }
+      >
+        <DropdownMenuSection label="Columns">
+          {HIDEABLE_COLUMNS.map((col) => (
+            <DropdownMenuItem
+              key={col.key}
+              label={col.label}
+              icon={
+                hiddenColumns.includes(col.key) ? undefined : (
+                  <Check size={14} />
+                )
+              }
+              onClick={() => {
+                // Computed outside the updater so the updater stays pure —
+                // StrictMode double-invokes updaters in development.
+                const next = hiddenColumns.includes(col.key)
+                  ? hiddenColumns.filter((k) => k !== col.key)
+                  : [...hiddenColumns, col.key]
+                setHiddenColumns(next)
+                writeHiddenColumns(next)
+              }}
+            />
+          ))}
+        </DropdownMenuSection>
+      </DropdownMenu>
+
+      <DropdownMenu
+        align="right"
+        trigger={
+          <Button variant="secondary" leftSection={<ArrowUpDown size={14} />}>
+            Sort
+          </Button>
+        }
+      >
+        <DropdownMenuSection label="Sort by">
+          {SERVICE_LIST_SORT.map((opt) => (
+            <DropdownMenuItem
+              key={opt.value}
+              label={opt.label}
+              icon={listSort === opt.value ? <Check size={14} /> : undefined}
+              onClick={() => applySort(opt.value)}
+            />
+          ))}
+        </DropdownMenuSection>
+        <DropdownMenuSection label="Direction">
+          <DropdownMenuItem
+            label="Ascending"
+            icon={sortDir === 'asc' ? <Check size={14} /> : undefined}
+            onClick={() => patchQuery({ sortDir: 'asc', page: '1' })}
+          />
+          <DropdownMenuItem
+            label="Descending"
+            icon={sortDir === 'desc' ? <Check size={14} /> : undefined}
+            onClick={() => patchQuery({ sortDir: 'desc', page: '1' })}
+          />
+        </DropdownMenuSection>
+      </DropdownMenu>
+    </>
+  )
 
   return (
     <div className="ash-content">
@@ -527,78 +776,40 @@ export function ServicesPage() {
           </h3>
           <p style={{ margin: 0 }}>Deploy an application to get started.</p>
         </div>
-      ) : null}
-
-      {initialLoading ? (
-        <div aria-busy>
-          <ColumnHeaders />
-          {[0, 1, 2, 3, 4].map((i) => (
-            <div key={i} style={ROW_GRID}>
-              <Skeleton height={16} />
-              <Skeleton height={16} />
-              <Skeleton height={16} />
-              <Skeleton height={16} />
-              <Skeleton height={16} />
-              <Skeleton height={16} />
-              <Skeleton height={16} />
-              <span />
-            </div>
-          ))}
-        </div>
-      ) : null}
-
-      {!initialLoading && deps.length > 0 ? (
-        <SortableList<ListItem>
-          items={visibleItems}
-          sortOptions={SERVICE_LIST_SORT}
-          defaultSort="name"
-          routeQuery={listQuery}
-          onRouteChange={setListQuery}
-          searchPlaceholder="Filter applications…"
+      ) : (
+        <DataTableCard<ListItem>
+          columns={columns}
+          rows={pageItems}
+          skeleton={initialLoading}
+          skeletonRowCount={5}
           emptyMessage={emptyMessage}
-          getItemGroup={(item, sortBy) =>
-            sortBy === 'status' ? primaryServicePartition(item.d) : null
+          totalCount={visibleItems.length}
+          countLabel="applications"
+          page={clampedPage}
+          totalPages={totalPages}
+          pageSize={PAGE_SIZE}
+          onPageChange={(p) => patchQuery({ page: String(p) })}
+          sortKey={listSort}
+          sortDir={sortDir}
+          onSort={(key) => applySort(key)}
+          onRowClick={({ d }) =>
+            navigate(
+              serviceDetailPath(
+                String(d._envId),
+                d.metadata.namespace,
+                d.metadata.name,
+                'overview',
+              ),
+            )
           }
-          getGroupInfo={(key) => SVC_STATUS_GROUP[key] ?? { name: String(key) }}
-          getGroupOrder={(sortBy) =>
-            sortBy === 'status' ? STATUS_SORT_ORDER : null
-          }
-          filterItem={(item, q) => {
-            const envN = item.d._envName || ''
-            const n = item.d.metadata.name
-            const { label } = rowStatus(item.d)
-            return `${n} ${envN} ${label}`.toLowerCase().includes(q)
-          }}
-          renderColumnHeaders={() => <ColumnHeaders />}
-          renderItem={(item) => (
-            <ServiceRow
-              key={item.id}
-              d={item.d}
-              envStatusClientCache={envStatusClientCache}
-              onOpen={() =>
-                navigate(
-                  serviceDetailPath(
-                    String(item.d._envId),
-                    item.d.metadata.namespace,
-                    item.d.metadata.name,
-                    'overview',
-                  ),
-                )
-              }
-              onViewLogs={() =>
-                navigate(
-                  serviceDetailPath(
-                    String(item.d._envId),
-                    item.d.metadata.namespace,
-                    item.d.metadata.name,
-                    'logs',
-                  ),
-                )
-              }
-            />
-          )}
+          searchValue={search}
+          onSearchChange={(v) => patchQuery({ filter: v, page: '1' })}
+          searchPlaceholder="Filter applications…"
+          // Matches the header buttons, which are Button's default 'base'.
+          controlSize="base"
+          actions={headerActions}
         />
-      ) : null}
+      )}
     </div>
   )
 }

--- a/client/src/pages/service-detail/ServiceDetailPage.tsx
+++ b/client/src/pages/service-detail/ServiceDetailPage.tsx
@@ -416,7 +416,7 @@ export function ServiceDetailPage() {
                   // git annotations means no cleanup and no checkbox, and the
                   // delete still reports success.
                   disabled={!d || !perms?.canDelete}
-                  title={
+                  disabledReason={
                     !perms?.canDelete
                       ? 'You do not have permission to delete workloads in this environment'
                       : undefined


### PR DESCRIPTION
Updates the design-system submodule and adopts what the new version makes possible: the Applications list moves from `SortableList` to `DataTable`, and the application detail breadcrumb becomes an app switcher.

## Why

The submodule was ~40 commits behind. Reading the changelog surfaced several things worth adopting — some replacing local workarounds, some fixing behaviour that never worked.

## What changed

**`chore`: design-system `029d801` → `4979939`.** Nothing breaking. Landing automatically, since the app defines no token overrides: the dark theme is de-blued, the dark-mode dropdown hover goes from ~1.15:1 to 3.2:1 (clearing WCAG AA non-text), and floating panels resolve `--shadow-popover` instead of an invisible hardcoded shadow.

**`feat(applications)`: `SortableList` → `DataTableCard`,** with the header pattern the design team is standardising on — search left, filter beside it, View/Sort right.

- **Environment** filters to one environment.
- **View** toggles column visibility, persisted to `localStorage`. Unknown keys are dropped on read so a renamed column can't leave a permanently hidden ghost.
- **Sort** shares state with the column headers — clicking a header updates the menu's check marks and vice versa.
- Column widths rebalanced; `controlSize="base"` matches the search input to the buttons.

**`feat(shell)`: breadcrumb app switcher.** The app-name crumb becomes an inline `ApplicationSwitcher`, so you can jump app to app without going back to the list. The current tab carries across — one app's Logs goes to another's Logs.

**`fix`: two permission tooltips that could never appear.** Delete, Logs and Restart each carried a `title` explaining a missing permission, but a native-disabled element fires no hover or focus events in any browser, so none of that copy was ever reachable. Now `disabledReason`, which uses `aria-disabled` and blocks the click by hand.

Also removes the CSS hack that hid the favourite star by matching on `aria-label="Add to favourites"`, replaced by the `showStar` prop. It would have broken silently on any rewording of that string.

## For the reviewer

**Health grouping is gone.** `SortableList` rendered group headers per health partition when sorting by Health. `DataTable` has no grouping. Sorting by Health still orders rows by partition, without the headers. This is the one real capability loss — flagging it in case it matters more than it appeared to.

**The summary-bar health filter is dead, and was already.** `StatusBar` declares `active` and `onClick` on its items but never reads either — a different component in that file implements them. Verified against the previously pinned commit too, so it is not a regression from this branch. `selectSubFilter` is left wired so it works the moment that's fixed upstream.

**Sidebar auto-collapse now kicks in at 1024px, up from 767px,** and is a live `matchMedia` subscription rather than a mount-only check. No prop overrides it. Verified at 1280px (expanded), 900px (icon rail, in-flow), 900px + manual toggle (stays expanded), and 380px (overlay drawer).

## Design-system bugs found, worth filing upstream

1. `SortableList`'s footer wraps — `Pagination` gained `width: 100%` for `DataTable`'s sake, but `SortableList` still pairs it with its own external summary. Moot for this page now, but live for any other consumer.
2. `ProgressRing` declares `showValue` and `strokeWidth` and destructures neither; its sibling `ProgressRingItem` implements both.
3. `StatusBar` ignores `active`/`onClick`, per above.

All three are the same shape: two components sharing one props interface, only one implementing it.

## Verification

Typecheck, lint (2 pre-existing warnings in untouched files), build, 11/11 tests, and `format:check` all pass. Every control was exercised in the browser against a live Portainer instance: filter, column hide/show plus reload persistence, sort from both the menu and the headers, row click, pagination, and app switching from both Overview and Logs.

Not included: `.claude/launch.json`, a local dev-server config, left untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
