### PR TITLE
feat(credential): report a credential broken after startup [R8S-1278]

### DIFF
--- a/server/handler.js
+++ b/server/handler.js
@@ -26,6 +26,8 @@ import { handleMcp } from './routes/mcp.js'
 import { handleSetup } from './routes/setup.js'
 import { resolveCallerIdentity } from './lib/identity.js'
 
+const PROBE_PROOF_WAIT_MS = 2_000
+
 /**
  * @param {import('http').IncomingMessage} req
  * @param {import('http').ServerResponse} res
@@ -62,9 +64,16 @@ export async function handleRequest(req, res) {
   // probes: this one answers 401 so Portainer can offer a repair, where a
   // Kubernetes probe would restart the pod and fix nothing.
   if (pathname === '/healthz') {
-    // Portainer polls this, so let its probe pick up a repaired Secret. Not
-    // awaited, so the probe does not wait on a round trip to answer.
-    void ensureHydrated().catch(() => {})
+    // Awaited, or the probe that finds a fault still answers from before the
+    // check, and the add-on list stops polling once everything is healthy.
+    // Bounded under Portainer's 3s probe timeout: a late answer reads as an
+    // add-on that is down.
+    await Promise.race([
+      ensureHydrated().catch(() => {}),
+      new Promise((resolve) =>
+        setTimeout(resolve, PROBE_PROOF_WAIT_MS).unref(),
+      ),
+    ])
 
     const status = credentialHealth()
     const code = { ok: 200, 'credential-invalid': 401 }[status] ?? 503

--- a/server/lib/credential-fault.js
+++ b/server/lib/credential-fault.js
@@ -1,0 +1,66 @@
+/**
+ * Whether this add-on's own credential still works, as every call to Portainer
+ * finds out. Kept out of settings, which stop calling once hydrated.
+ */
+
+/** @typedef {'rejected' | 'certificate'} Fault */
+
+/** @type {Fault | null} */
+let fault = null
+
+/** @returns {Fault | null} */
+export function credentialFailure() {
+  return fault
+}
+
+/**
+ * What one call to Portainer proves about the credential.
+ *
+ * A rejection counts only where the add-on presented its own credential; a
+ * certificate counts whoever called, since the pin is on the certificate
+ * rather than the token. 401 only: the machine API answers 401 for every
+ * authentication failure, so a 403 is a credential Portainer knows.
+ *
+ * @param {{
+ *   usedMachineCredential?: boolean,
+ *   status?: number | null,
+ *   certificateTrusted?: boolean | null,
+ * }} outcome
+ * @returns {{ record: Fault } | { clear: 'all' | 'certificate' } | null}
+ */
+export function classifyOutcome({
+  usedMachineCredential = false,
+  status = null,
+  certificateTrusted = null,
+}) {
+  if (certificateTrusted === false) {
+    return { record: 'certificate' }
+  }
+
+  if (certificateTrusted === true) return { clear: 'certificate' }
+
+  // Unreachable says nothing about the credential.
+  if (status === null) return null
+
+  if (status === 401) {
+    return usedMachineCredential ? { record: 'rejected' } : null
+  }
+
+  // Anything else says nothing, so it must not clear a known rejection.
+  if (status >= 400) return null
+
+  return { clear: usedMachineCredential ? 'all' : 'certificate' }
+}
+
+/** Apply what a call proved. @param {Parameters<typeof classifyOutcome>[0]} outcome */
+export function noteOutcome(outcome) {
+  const verdict = classifyOutcome(outcome)
+  if (!verdict) return
+
+  if ('record' in verdict) {
+    fault = verdict.record
+    return
+  }
+
+  if (verdict.clear === 'all' || fault === 'certificate') fault = null
+}

--- a/server/lib/credential-fault.test.js
+++ b/server/lib/credential-fault.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { classifyOutcome } from './credential-fault.js'
+
+/** @param {Partial<Parameters<typeof classifyOutcome>[0]>} outcome */
+function verdict(outcome) {
+  return classifyOutcome(outcome)
+}
+
+test('an untrusted certificate is a fault whoever called', () => {
+  assert.deepEqual(verdict({ certificateTrusted: false }), {
+    record: 'certificate',
+  })
+})
+
+test('a verified handshake clears a certificate fault on any call', () => {
+  assert.deepEqual(verdict({ certificateTrusted: true }), {
+    clear: 'certificate',
+  })
+})
+
+test("the add-on's own credential being refused is a fault", () => {
+  assert.deepEqual(verdict({ usedMachineCredential: true, status: 401 }), {
+    record: 'rejected',
+  })
+})
+
+test('the add-on being denied a route is not a credential fault', () => {
+  assert.equal(verdict({ usedMachineCredential: true, status: 403 }), null)
+})
+
+test("a caller's own token being refused says nothing", () => {
+  assert.equal(verdict({ usedMachineCredential: false, status: 401 }), null)
+})
+
+test('an unreachable Portainer says nothing', () => {
+  assert.equal(verdict({ usedMachineCredential: true, status: null }), null)
+})
+
+test('a server error says nothing, so it cannot clear a rejection', () => {
+  assert.equal(verdict({ usedMachineCredential: true, status: 500 }), null)
+  assert.equal(verdict({ usedMachineCredential: true, status: 404 }), null)
+})
+
+test('a call that worked on the machine credential clears everything', () => {
+  assert.deepEqual(verdict({ usedMachineCredential: true, status: 200 }), {
+    clear: 'all',
+  })
+})
+
+test('a call that worked on a borrowed admin token leaves a rejection standing', () => {
+  assert.deepEqual(verdict({ usedMachineCredential: false, status: 200 }), {
+    clear: 'certificate',
+  })
+})

--- a/server/lib/portainer-api.js
+++ b/server/lib/portainer-api.js
@@ -1,5 +1,7 @@
 import { portainerAuthHeaders } from './identity.js'
 import { portainerHttpRequest } from './portainer-tls.js'
+import { noteOutcome } from './credential-fault.js'
+import { machineToken } from '../machine-credential.js'
 
 /**
  * Request Portainer's API. `token` is either the inbound caller's own
@@ -20,6 +22,9 @@ export function portainerRequest(
   body,
   contentType = 'application/json',
 ) {
+  const machine = machineToken()
+  const usedMachineCredential = Boolean(machine) && token === machine
+
   return new Promise((resolve, reject) => {
     const headers = { 'Content-Type': contentType, Accept: 'application/json' }
     if (token) Object.assign(headers, portainerAuthHeaders(token))
@@ -33,6 +38,7 @@ export function portainerRequest(
         upRes.on('data', (c) => chunks.push(c))
         upRes.on('end', () => {
           const text = Buffer.concat(chunks).toString('utf8')
+          noteOutcome({ usedMachineCredential, status: upRes.statusCode })
           if (upRes.statusCode >= 400) {
             // Keep the method/path/status alongside Portainer's own message so a
             // routing 404 ("Not Found") is distinguishable from a resource 404.

--- a/server/lib/portainer-api.js
+++ b/server/lib/portainer-api.js
@@ -22,8 +22,8 @@ export function portainerRequest(
   body,
   contentType = 'application/json',
 ) {
-  const machine = machineToken()
-  const usedMachineCredential = Boolean(machine) && token === machine
+  const usedMachineCredential =
+    token.startsWith('paddon_') && token === machineToken()
 
   return new Promise((resolve, reject) => {
     const headers = { 'Content-Type': contentType, Accept: 'application/json' }

--- a/server/lib/portainer-tls.js
+++ b/server/lib/portainer-tls.js
@@ -7,6 +7,7 @@
 import https from 'node:https'
 import http from 'node:http'
 import { portainerCA, portainerCAUnreadable } from '../machine-credential.js'
+import { noteOutcome } from './credential-fault.js'
 
 /** Without this, a blackholed Portainer hangs every request queued behind it. */
 const READ_TIMEOUT_MS = 10_000
@@ -139,9 +140,17 @@ function verifyPeer(req, socket) {
   // for a binding this does not rely on, and expiry has no republishing of its
   // own — a Repair would hand back the same certificate, with no way out.
   const leaf = socket.getPeerCertificate(false)?.raw
-  if (leaf && publishedCertificates(ca).some((der) => der.equals(leaf))) return
+  if (leaf && publishedCertificates(ca).some((der) => der.equals(leaf))) {
+    noteOutcome({ certificateTrusted: true })
+    return
+  }
 
-  if (socket.authorized) return
+  if (socket.authorized) {
+    noteOutcome({ certificateTrusted: true })
+    return
+  }
+
+  noteOutcome({ certificateTrusted: false })
 
   const err = new Error(
     "Portainer's TLS certificate is neither the one published with the add-on " +

--- a/server/machine-credential.js
+++ b/server/machine-credential.js
@@ -85,8 +85,14 @@ function fail(name, file, e) {
   return entry
 }
 
+/** Latched, so a credential that disappears is told apart from one never issued. */
+let everIssued = false
+
 export function machineToken() {
-  return read(TOKEN_FILE).content?.toString('utf8').trim() || ''
+  const token = read(TOKEN_FILE).content?.toString('utf8').trim() || ''
+  if (token) everIssued = true
+
+  return token
 }
 
 /** Portainer's own TLS certificate, or null where it serves plain HTTP. */
@@ -96,6 +102,14 @@ export function portainerCA() {
 
 export function hasMachineCredential() {
   return machineToken() !== ''
+}
+
+/**
+ * Whether a credential this add-on was issued has since gone. Repair
+ * republishes the Secret, so unlike never having one, this has a remedy.
+ */
+export function credentialWithdrawn() {
+  return everIssued && !hasMachineCredential()
 }
 
 /**

--- a/server/settings.js
+++ b/server/settings.js
@@ -11,11 +11,13 @@
 import { portainerRequest } from './lib/portainer-api.js'
 import { resolvePortainerTarget } from './resolve-portainer.js'
 import {
+  credentialWithdrawn,
   hasMachineCredential,
   machineToken,
   machineTokenUnreadable,
   portainerCAUnreadable,
 } from './machine-credential.js'
+import { credentialFailure } from './lib/credential-fault.js'
 
 const ADDON_ID = 'portainer-run'
 
@@ -52,8 +54,6 @@ let hydratedAt = null
 let lastError = null
 /** @type {Promise<boolean> | null} */
 let inFlight = null
-/** Why this add-on's own credential last failed: null, 'rejected' or 'certificate'. */
-let credentialFailure = null
 /** Whether Portainer holds this add-on's ENCRYPTION_KEY. */
 let keyCameFromPortainer = false
 /**
@@ -133,10 +133,12 @@ export function credentialHealth() {
   // cannot present, so ask that before asking whether it works.
   if (credentialUnreadable()) return 'credential-invalid'
 
-  // A credential since removed has nothing left to repair.
+  if (credentialWithdrawn()) return 'credential-invalid'
+
+  // Never issued one: nothing to repair.
   if (!hasMachineCredential()) return 'ok'
 
-  if (credentialFailure) return 'credential-invalid'
+  if (credentialFailure()) return 'credential-invalid'
   // Env-seeded settings skip hydration, so never hydrating is not a fault.
   if (hydratedAt === null && !isConfigured()) return 'settings-unavailable'
 
@@ -155,31 +157,25 @@ const HYDRATE_RETRY_INTERVAL = 15_000
 let lastHydrateAttempt = 0
 
 /**
- * Which half of the credential failed. A refused token and an untrusted
- * certificate need the same repair, so /healthz reports which one it was
- * without echoing the upstream message to an unauthenticated caller.
- *
- * @returns {'rejected' | 'certificate' | null}
+ * How long a hydrated add-on trusts its last proof that the credential works.
+ * Nothing expires the settings themselves; an add-on nobody is using makes no
+ * other call to find a credential broken since.
  */
-function failureCause(e) {
-  if (e?.status === 401 || e?.status === 403) return 'rejected'
+const CREDENTIAL_PROOF_TTL = 5 * 60_000
 
-  const code = e?.code
-  if (
-    typeof code === 'string' &&
-    (code.includes('CERT') || code.startsWith('ERR_TLS'))
-  ) {
-    return 'certificate'
-  }
+function overdueForProof() {
+  // Env seeds were never proved by a call, so there is nothing to re-prove.
+  if (hydratedAt === null) return false
 
-  return null
+  return Date.now() - hydratedAt >= CREDENTIAL_PROOF_TTL
 }
 
-/** @returns {'rejected' | 'certificate' | 'unreadable' | undefined} */
+/** @returns {'rejected' | 'certificate' | 'unreadable' | 'withdrawn' | undefined} */
 export function credentialFault() {
   if (credentialUnreadable()) return 'unreadable'
+  if (credentialWithdrawn()) return 'withdrawn'
 
-  return credentialFailure ?? undefined
+  return credentialFailure() ?? undefined
 }
 
 /**
@@ -201,7 +197,7 @@ async function hydrate(adminToken) {
   // that credential has been refused, so a broken one can be recovered without
   // uninstalling.
   const asAdmin =
-    Boolean(adminToken) && (!machine || credentialFailure !== null)
+    Boolean(adminToken) && (!machine || credentialFailure() !== null)
   const token = asAdmin ? adminToken : machine
   if (!token) {
     lastError =
@@ -231,16 +227,9 @@ async function hydrate(adminToken) {
     hydratedAt = Date.now()
     lastError = null
     keyCameFromPortainer = 'ENCRYPTION_KEY' in fetched
-    // A borrowed admin token says nothing about this add-on's credential, so a
-    // fetch that worked around a broken one leaves the fault standing.
-    if (!asAdmin) credentialFailure = null
     return true
   } catch (e) {
     lastError = e instanceof Error ? e.message : String(e)
-    // Only a recognised cause replaces a recorded one. A 500 says nothing about
-    // the credential, and letting it clear a known rejection would report the
-    // add-on healthy with nothing left to retry.
-    if (!asAdmin) credentialFailure = failureCause(e) ?? credentialFailure
     return false
   }
 }
@@ -293,7 +282,7 @@ export function refetch(adminToken) {
 export function ensureHydrated(adminToken) {
   // Settings can be live from an env seed or an earlier fetch while the
   // credential is not, so being configured is not on its own a reason to stop.
-  if (isConfigured() && credentialHealth() === 'ok')
+  if (isConfigured() && credentialHealth() === 'ok' && !overdueForProof())
     return Promise.resolve(true)
   if (!machineToken() && !adminToken) return Promise.resolve(false)
   if (inFlight) return inFlight


### PR DESCRIPTION
Records a broken add-on credential from any call to Portainer, not just the settings fetch, which stops running once the add-on is hydrated. A rotated certificate or a rejected token now reports credential-invalid without restarting the pod.

## Verification
- Replace Portainer's certificate (Settings → SSL), then open the Add-ons page. Portainer-Run reports Credential invalid within five minutes, with no pod restart.
- Click Repair. The badge returns to Running, still without a restart.
- Patch the add-on's Secret token to a bogus value (`kubectl -n portainer-addon-portainer-run patch secret portainer-run-token --type merge -p '{"stringData":{"token":"paddon_bogus"}}'`). Same badge; `/healthz` reports `fault: "rejected"`.
- Repair again, then save a setting in the add-on to confirm the reload works.
- With the add-on healthy, time `/healthz`. It answers inside Portainer's 3s probe timeout.

Ticket: https://linear.app/portainer/issue/R8S-1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)