### PR TITLE
feat(deploy): give app Ingresses a tls: block when a wildcard secret exists [PLA-955]

### DIFF
--- a/server/lib/ingress-tls.js
+++ b/server/lib/ingress-tls.js
@@ -1,0 +1,26 @@
+/**
+ * An app's Ingress gets no `tls:` block of its own today — it depends
+ * entirely on whatever cluster-wide default certificate the ingress
+ * controller happens to provide, which isn't consistent across controllers.
+ *
+ * Deliberately doesn't read or cache a certificate anywhere: it only checks,
+ * at deploy time, whether a Secret with this well-known name already exists
+ * in the app's own namespace, and references it if so. Getting that Secret
+ * into a namespace in the first place is a separate concern this module
+ * knows nothing about.
+ *
+ * Must match `secretName` in the installer's own `internal/stages/tls/tls.go`
+ * exactly — there's no shared code enforcing this across the two repos, so
+ * the name is a manual cross-repo contract.
+ */
+export const WILDCARD_TLS_SECRET_NAME = 'portainer-run-wildcard-tls'
+
+/**
+ * The `spec.tls` value for an Ingress that should use the wildcard secret.
+ *
+ * @param {string} host
+ * @returns {{ hosts: string[], secretName: string }[]}
+ */
+export function wildcardTlsBlock(host) {
+  return [{ hosts: [host], secretName: WILDCARD_TLS_SECRET_NAME }]
+}

--- a/server/lib/ingress-tls.test.js
+++ b/server/lib/ingress-tls.test.js
@@ -1,0 +1,15 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { WILDCARD_TLS_SECRET_NAME, wildcardTlsBlock } from './ingress-tls.js'
+
+test('wildcardTlsBlock references the well-known secret for the given host', () => {
+  assert.deepEqual(wildcardTlsBlock('hello.run.example.com'), [
+    { hosts: ['hello.run.example.com'], secretName: WILDCARD_TLS_SECRET_NAME },
+  ])
+})
+
+// The name is a manual cross-repo contract with the installer's tls.go — pin
+// it explicitly so an accidental rename here doesn't silently break that.
+test('the secret name matches the installer-side constant', () => {
+  assert.equal(WILDCARD_TLS_SECRET_NAME, 'portainer-run-wildcard-tls')
+})

--- a/server/lib/ingress-tls.test.js
+++ b/server/lib/ingress-tls.test.js
@@ -1,15 +1,12 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { WILDCARD_TLS_SECRET_NAME, wildcardTlsBlock } from './ingress-tls.js'
+import { wildcardTlsBlock } from './ingress-tls.js'
 
 test('wildcardTlsBlock references the well-known secret for the given host', () => {
   assert.deepEqual(wildcardTlsBlock('hello.run.example.com'), [
-    { hosts: ['hello.run.example.com'], secretName: WILDCARD_TLS_SECRET_NAME },
+    {
+      hosts: ['hello.run.example.com'],
+      secretName: 'portainer-run-wildcard-tls',
+    },
   ])
-})
-
-// The name is a manual cross-repo contract with the installer's tls.go — pin
-// it explicitly so an accidental rename here doesn't silently break that.
-test('the secret name matches the installer-side constant', () => {
-  assert.equal(WILDCARD_TLS_SECRET_NAME, 'portainer-run-wildcard-tls')
 })

--- a/server/routes/vibe.js
+++ b/server/routes/vibe.js
@@ -20,6 +20,10 @@ import { resolveCallerIdentity, extractToken } from '../lib/identity.js'
 import { portainerRequest } from '../lib/portainer-api.js'
 import { findHostConflict, hostConflictMessage } from '../lib/ingress-host.js'
 import {
+  wildcardTlsBlock,
+  WILDCARD_TLS_SECRET_NAME,
+} from '../lib/ingress-tls.js'
+import {
   findStackNameConflict,
   stackNameConflictMessage,
 } from '../lib/stack-name.js'
@@ -357,6 +361,7 @@ function buildVibeManifests({
   exposeType,
   servicePorts,
   ingress,
+  hasWildcardTlsSecret,
   gitopsAnnotations,
   gitRepoUrl,
   gitBranch,
@@ -627,6 +632,13 @@ function buildVibeManifests({
           ...(ingress.ingressClass
             ? { ingressClassName: ingress.ingressClass }
             : {}),
+          // Reference the wildcard secret only when the caller already
+          // confirmed it exists in this namespace — never guessed at here,
+          // since a tls: block naming a Secret that doesn't exist is worse
+          // than no tls: block at all.
+          ...(hasWildcardTlsSecret
+            ? { tls: wildcardTlsBlock(ingress.host) }
+            : {}),
           rules: [
             {
               host: ingress.host,
@@ -852,6 +864,13 @@ async function handleVibeDeploy(req, res) {
     const initCredToken = isGitSource ? sourceGitToken : gitToken
     const initCredUsername = isGitSource ? sourceGitUsername : gitUsername
 
+    // Checked fresh on every deploy, never cached — see
+    // checkWildcardTlsSecret's own doc for why.
+    const hasWildcardTlsSecret =
+      exposeType === 'Ingress' && ingress?.host
+        ? await checkWildcardTlsSecret(req, { envId, ns })
+        : false
+
     const manifests = buildVibeManifests({
       appName: safeApp,
       ns,
@@ -860,6 +879,7 @@ async function handleVibeDeploy(req, res) {
       exposeType: exposeType || 'none',
       servicePorts: servicePorts || [3000],
       ingress: ingress || {},
+      hasWildcardTlsSecret,
       gitopsAnnotations,
       gitRepoUrl: initCloneUrl,
       gitBranch: initBranch,
@@ -1061,6 +1081,42 @@ async function findIngressHostConflict(req, { envId, ns, appName, host }) {
 
   const conflict = findHostConflict(ingresses, host, { ns, appName })
   return conflict ? hostConflictMessage(host, conflict) : null
+}
+
+/**
+ * Whether the app's own namespace already has the wildcard TLS secret —
+ * checked fresh on every deploy rather than cached anywhere, so a secret
+ * added, rotated, or removed between deploys is always picked up on the next
+ * one. Best-effort like every other pre-deploy check here: a namespace the
+ * caller cannot read, or a Portainer/network hiccup, means "no secret found",
+ * not a hard failure — Ingress creation must never break over this optional
+ * enhancement.
+ *
+ * @returns {Promise<boolean>}
+ */
+async function checkWildcardTlsSecret(req, { envId, ns }) {
+  const target = resolvePortainerTarget()
+  if (!target || !envId) return false
+
+  try {
+    await portainerRequest(
+      target,
+      extractToken(req),
+      'GET',
+      `/api/endpoints/${envId}/kubernetes/api/v1/namespaces/${ns}/secrets/${WILDCARD_TLS_SECRET_NAME}`,
+    )
+    return true
+  } catch (err) {
+    // A 404 is the normal, expected "not present yet" case — not worth logging.
+    if (err?.status !== 404) {
+      console.warn('[vibe] wildcard TLS secret check skipped', {
+        message: err?.message || String(err),
+        envId,
+        ns,
+      })
+    }
+    return false
+  }
 }
 
 /**
@@ -1357,6 +1413,13 @@ async function handleVibeUpdateExposure(req, res) {
       newDocs.push(serializeManifests([svc]).trim())
 
       if (exposeType === 'Ingress' && ingress?.host) {
+        // Checked fresh on every deploy, never cached — see
+        // checkWildcardTlsSecret's own doc for why.
+        const hasWildcardTlsSecret = await checkWildcardTlsSecret(req, {
+          envId,
+          ns,
+        })
+
         const ing = {
           apiVersion: 'networking.k8s.io/v1',
           kind: 'Ingress',
@@ -1377,6 +1440,9 @@ async function handleVibeUpdateExposure(req, res) {
             // annotation above is kept for legacy controllers).
             ...(ingress.ingressClass
               ? { ingressClassName: ingress.ingressClass }
+              : {}),
+            ...(hasWildcardTlsSecret
+              ? { tls: wildcardTlsBlock(ingress.host) }
               : {}),
             rules: [
               {

--- a/server/routes/vibe.js
+++ b/server/routes/vibe.js
@@ -1113,10 +1113,14 @@ async function checkWildcardTlsSecret(req, { envId, ns }) {
     )
     return true
   } catch (err) {
-    // A 404 is the normal, expected "not present yet" case — not worth logging.
-    if (err?.status !== 404) {
+    // 404 (secret not present yet) and 401/403 (caller can't read Secrets in
+    // this namespace — expected whenever the deploying user's own RBAC
+    // doesn't grant it, per this function's own best-effort contract above)
+    // are all normal, expected outcomes — not worth logging.
+    if (![401, 403, 404].includes(err?.status)) {
       console.warn('[vibe] wildcard TLS secret check skipped', {
         message: err?.message || String(err),
+        status: err?.status,
         envId,
         ns,
       })

--- a/server/routes/vibe.js
+++ b/server/routes/vibe.js
@@ -1098,12 +1098,18 @@ async function checkWildcardTlsSecret(req, { envId, ns }) {
   const target = resolvePortainerTarget()
   if (!target || !envId) return false
 
+  // Validate envId is numeric to prevent path injection into the Portainer
+  // API, same as listVisibleIngresses; ns is free-form request data, so it
+  // must be encoded rather than interpolated raw into the URL path.
+  const safeEnvId = String(envId)
+  if (!/^\d+$/.test(safeEnvId)) return false
+
   try {
     await portainerRequest(
       target,
       extractToken(req),
       'GET',
-      `/api/endpoints/${envId}/kubernetes/api/v1/namespaces/${ns}/secrets/${WILDCARD_TLS_SECRET_NAME}`,
+      `/api/endpoints/${safeEnvId}/kubernetes/api/v1/namespaces/${encodeURIComponent(ns)}/secrets/${WILDCARD_TLS_SECRET_NAME}`,
     )
     return true
   } catch (err) {


### PR DESCRIPTION
- App Ingresses now get a `tls:` block when a Secret named `portainer-run-wildcard-tls` already exists in the app's namespace
- Checked live at deploy time, not cached — always reflects the current state of that namespace
- Read-only check, so no new Kubernetes permissions are needed

Ref: PLA-955